### PR TITLE
Use curried onChange and onBlur functions in useField

### DIFF
--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -4,15 +4,9 @@ title: React Native
 custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/guides/react-native.md
 ---
 
-**Formik is 100% compatible with React Native and React Native Web.** However,
-because of differences between ReactDOM's and React Native's handling of forms
-and text input, there are some differences to be aware of. This section will walk
-you through them and what we consider to be best practices.
+**Formik is 100% compatible with React Native and React Native Web.** However, because of differences between ReactDOM's and React Native's handling of forms and text input, there are some differences to be aware of. This section will walk you through them and what we consider to be best practices.
 
-### The gist
-
-Before going any further, here's a super minimal gist of how to use Formik with
-React Native that demonstrates the key differences:
+### Basic usage
 
 ```jsx
 // Formik x React Native example
@@ -28,8 +22,8 @@ export const MyReactNativeForm = props => (
     {({ handleChange, handleBlur, handleSubmit, values }) => (
       <View>
         <TextInput
-          onChangeText={handleChange('email')}
-          onBlur={handleBlur('email')}
+          onChangeText={handleChange}
+          onBlur={handleBlur}
           value={values.email}
         />
         <Button onPress={handleSubmit} title="Submit" />
@@ -43,6 +37,47 @@ As you can see above, the notable differences between using Formik with React
 DOM and React Native are:
 
 1.  Formik's `handleSubmit` is passed to a `<Button onPress={...} />`
-    instead of HTML `<form onSubmit={...} />` component (since there is no
+    instead of the HTML `<form onSubmit={...} />` component (since there is no
     `<form />` element in React Native).
-2.  `<TextInput />` uses Formik's `handleChange(fieldName)` and `handleBlur(fieldName)` instead of directly assigning the callbacks to props, because we have to get the `fieldName` from somewhere and with React Native we can't get it automatically like in web (using input name attribute). You can also use `setFieldValue(fieldName, value)` and `setFieldTouched(fieldName, bool)` as an alternative.
+2.  Formik's `handleChange` is passed to a `<TextInput onChangeText={...} />` instead of the HTML `<input onChange={...} />` component since we only need the updated text from the input rather than the whole event (although Formik will also work with `<TextInput onChange={handleChange} / >`).
+
+### The `useField` hook
+
+We can also take advantage of Formik's `useField` hook in React Native. Take the following example:
+
+```jsx
+// Formik x React Native with hooks
+import React from 'react';
+import { Button, Text, TextInput, View } from 'react-native';
+import { Formik, useField } from 'formik';
+
+const MyCustomTextInput = ({ name, label }) => {
+  const [field, meta, helpers] = useField(name);
+
+  return (
+    <>
+      <Text>{label}</Text>
+      <TextInput
+        onChangeText={field.onChange}
+        onBlur={field.onBlur}
+        value={field.value}
+      />
+      {meta.error && meta.touched && <Text>{meta.error}</Text>}
+    </>
+  );
+};
+
+export const MyReactNativeForm = props => (
+  <Formik
+    initialValues={{ email: '' }}
+    onSubmit={values => console.log(values)}
+  >
+    {({ handleSubmit }) => (
+      <View>
+        <MyCustomTextInput name="email" label="Email" />
+        <Button onPress={handleSubmit} title="Submit" />
+      </View>
+    )}
+  </Formik>
+);
+```

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1,33 +1,33 @@
-import deepmerge from 'deepmerge';
-import isPlainObject from 'lodash/isPlainObject';
 import * as React from 'react';
 import isEqual from 'react-fast-compare';
-import { LowPriority, unstable_runWithPriority } from 'scheduler';
-import invariant from 'tiny-warning';
-import { FormikProvider } from './FormikContext';
+import deepmerge from 'deepmerge';
+import isPlainObject from 'lodash/isPlainObject';
 import {
-  FieldHelperProps,
-  FieldInputProps,
-  FieldMetaProps,
   FormikConfig,
   FormikErrors,
-  FormikHelpers,
-  FormikProps,
   FormikState,
   FormikTouched,
   FormikValues,
+  FormikProps,
+  FieldMetaProps,
+  FieldHelperProps,
+  FieldInputProps,
+  FormikHelpers,
 } from './types';
 import {
-  getActiveElement,
-  getIn,
-  isEmptyChildren,
   isFunction,
-  isObject,
-  isPromise,
   isString,
   setIn,
+  isEmptyChildren,
+  isPromise,
   setNestedObjectValues,
+  getActiveElement,
+  getIn,
+  isObject,
 } from './utils';
+import { FormikProvider } from './FormikContext';
+import invariant from 'tiny-warning';
+import { LowPriority, unstable_runWithPriority } from 'scheduler';
 
 type FormikMessage<Values> =
   | { type: 'SUBMIT_ATTEMPT' }

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1,33 +1,33 @@
-import * as React from 'react';
-import isEqual from 'react-fast-compare';
 import deepmerge from 'deepmerge';
 import isPlainObject from 'lodash/isPlainObject';
+import * as React from 'react';
+import isEqual from 'react-fast-compare';
+import { LowPriority, unstable_runWithPriority } from 'scheduler';
+import invariant from 'tiny-warning';
+import { FormikProvider } from './FormikContext';
 import {
+  FieldHelperProps,
+  FieldInputProps,
+  FieldMetaProps,
   FormikConfig,
   FormikErrors,
+  FormikHelpers,
+  FormikProps,
   FormikState,
   FormikTouched,
   FormikValues,
-  FormikProps,
-  FieldMetaProps,
-  FieldHelperProps,
-  FieldInputProps,
-  FormikHelpers,
 } from './types';
 import {
-  isFunction,
-  isString,
-  setIn,
-  isEmptyChildren,
-  isPromise,
-  setNestedObjectValues,
   getActiveElement,
   getIn,
+  isEmptyChildren,
+  isFunction,
   isObject,
+  isPromise,
+  isString,
+  setIn,
+  setNestedObjectValues,
 } from './utils';
-import { FormikProvider } from './FormikContext';
-import invariant from 'tiny-warning';
-import { LowPriority, unstable_runWithPriority } from 'scheduler';
 
 type FormikMessage<Values> =
   | { type: 'SUBMIT_ATTEMPT' }
@@ -906,14 +906,19 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   const getFieldProps = React.useCallback(
     (nameOrOptions): FieldInputProps<any> => {
       const isAnObject = isObject(nameOrOptions);
-      const name = isAnObject ? nameOrOptions.name : nameOrOptions;
+      const name: string = isAnObject ? nameOrOptions.name : nameOrOptions;
       const valueState = getIn(state.values, name);
+      // Use curried version of field
+      const onChange = handleChange(name) as (
+        eventOrString: string | React.ChangeEvent<any>
+      ) => void;
+      const onBlur = handleBlur(name) as (event: any) => void;
 
       const field: FieldInputProps<any> = {
         name,
         value: valueState,
-        onChange: handleChange,
-        onBlur: handleBlur,
+        onChange,
+        onBlur,
       };
       if (isAnObject) {
         const {

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
-import { cleanup, render, wait, fireEvent } from 'react-testing-library';
+import { cleanup, fireEvent, render, wait } from 'react-testing-library';
 import * as Yup from 'yup';
 import {
-  Formik,
-  Field,
   FastField,
-  FieldProps,
+  Field,
   FieldConfig,
-  FormikProps,
+  FieldProps,
+  Formik,
   FormikConfig,
+  FormikProps,
 } from '../src';
-
 import { noop } from './testHelpers';
 
 const initialValues = { name: 'jared', email: 'hello@reason.nyc' };
@@ -124,12 +123,11 @@ describe('Field / FastField', () => {
         </>
       );
 
-      const { handleBlur, handleChange } = getFormProps();
       injected.forEach((props, idx) => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
-        expect(props.field.onChange).toBe(handleChange('name'));
-        expect(props.field.onBlur).toBe(handleBlur('name'));
+        expect(props.field.onChange).toBeInstanceOf(Function);
+        expect(props.field.onBlur).toBeInstanceOf(Function);
         expect(props.form).toEqual(getFormProps());
         if (idx !== 2) {
           expect(props.meta.value).toBe('jared');
@@ -145,8 +143,8 @@ describe('Field / FastField', () => {
 
       expect(asInjectedProps.name).toBe('name');
       expect(asInjectedProps.value).toBe('jared');
-      expect(asInjectedProps.onChange).toBe(handleChange('name'));
-      expect(asInjectedProps.onBlur).toBe(handleBlur('name'));
+      expect(asInjectedProps.onChange).toBeInstanceOf(Function);
+      expect(asInjectedProps.onBlur).toBeInstanceOf(Function);
 
       expect(queryAllByText(TEXT)).toHaveLength(4);
     });
@@ -170,12 +168,11 @@ describe('Field / FastField', () => {
         </>
       );
 
-      const { handleBlur, handleChange } = getFormProps();
       injected.forEach((props, idx) => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
-        expect(props.field.onChange).toBe(handleChange('name'));
-        expect(props.field.onBlur).toBe(handleBlur('name'));
+        expect(props.field.onChange).toBeInstanceOf(Function);
+        expect(props.field.onBlur).toBeInstanceOf(Function);
         expect(props.form).toEqual(getFormProps());
         if (idx !== 2) {
           expect(props.meta.value).toBe('jared');
@@ -191,8 +188,8 @@ describe('Field / FastField', () => {
 
       expect(asInjectedProps.name).toBe('name');
       expect(asInjectedProps.value).toBe('jared');
-      expect(asInjectedProps.onChange).toBe(handleChange('name'));
-      expect(asInjectedProps.onBlur).toBe(handleBlur('name'));
+      expect(asInjectedProps.onChange).toBeInstanceOf(Function);
+      expect(asInjectedProps.onBlur).toBeInstanceOf(Function);
       expect(queryAllByText(TEXT)).toHaveLength(4);
     });
   });

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -128,8 +128,8 @@ describe('Field / FastField', () => {
       injected.forEach((props, idx) => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
-        expect(props.field.onChange).toBe(handleChange);
-        expect(props.field.onBlur).toBe(handleBlur);
+        expect(props.field.onChange).toBe(handleChange('name'));
+        expect(props.field.onBlur).toBe(handleBlur('name'));
         expect(props.form).toEqual(getFormProps());
         if (idx !== 2) {
           expect(props.meta.value).toBe('jared');
@@ -145,8 +145,8 @@ describe('Field / FastField', () => {
 
       expect(asInjectedProps.name).toBe('name');
       expect(asInjectedProps.value).toBe('jared');
-      expect(asInjectedProps.onChange).toBe(handleChange);
-      expect(asInjectedProps.onBlur).toBe(handleBlur);
+      expect(asInjectedProps.onChange).toBe(handleChange('name'));
+      expect(asInjectedProps.onBlur).toBe(handleBlur('name'));
 
       expect(queryAllByText(TEXT)).toHaveLength(4);
     });
@@ -174,8 +174,8 @@ describe('Field / FastField', () => {
       injected.forEach((props, idx) => {
         expect(props.field.name).toBe('name');
         expect(props.field.value).toBe('jared');
-        expect(props.field.onChange).toBe(handleChange);
-        expect(props.field.onBlur).toBe(handleBlur);
+        expect(props.field.onChange).toBe(handleChange('name'));
+        expect(props.field.onBlur).toBe(handleBlur('name'));
         expect(props.form).toEqual(getFormProps());
         if (idx !== 2) {
           expect(props.meta.value).toBe('jared');
@@ -191,8 +191,8 @@ describe('Field / FastField', () => {
 
       expect(asInjectedProps.name).toBe('name');
       expect(asInjectedProps.value).toBe('jared');
-      expect(asInjectedProps.onChange).toBe(handleChange);
-      expect(asInjectedProps.onBlur).toBe(handleBlur);
+      expect(asInjectedProps.onChange).toBe(handleChange('name'));
+      expect(asInjectedProps.onBlur).toBe(handleBlur('name'));
       expect(queryAllByText(TEXT)).toHaveLength(4);
     });
   });


### PR DESCRIPTION
Fixes #1674 and closes #2082. Bind the passed field name to the `handleChange` and `onChange` functions to remove the need for explicit binding when using `useField` with React Native while maintaining the current behavior on the web.