### PR TITLE
Fix translate attribute being required on <Form/> for users on @types/react <16.9.12

### DIFF
--- a/packages/formik/src/Form.tsx
+++ b/packages/formik/src/Form.tsx
@@ -6,8 +6,15 @@ export type FormikFormProps = Omit<
   'onReset' | 'onSubmit'
 >;
 
+// This type is the same that forwardRef returns. Assigning it explicitly seems
+// to stop TS from inlining all picked form attributes into the Form.d.ts file
+// which causes compilation to fail for users on different @types/react versions.
+type FormWrapper = React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<FormikFormProps> & React.RefAttributes<HTMLFormElement>
+>;
+
 // @todo tests
-export const Form = React.forwardRef<HTMLFormElement, FormikFormProps>(
+export const Form: FormWrapper = React.forwardRef<HTMLFormElement, FormikFormProps>(
   (props, ref) => {
     // iOS needs an "action" attribute for nice input: https://stackoverflow.com/a/39485162/406725
     // We default the action to "#" in case the preventDefault fails (just updates the URL hash)

--- a/packages/formik/src/Form.tsx
+++ b/packages/formik/src/Form.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import { useFormikContext } from './FormikContext';
 
-export type FormikFormProps = Pick<
+export type FormikFormProps = Omit<
   React.FormHTMLAttributes<HTMLFormElement>,
-  Exclude<
-    keyof React.FormHTMLAttributes<HTMLFormElement>,
-    'onReset' | 'onSubmit'
-  >
+  'onReset' | 'onSubmit'
 >;
 
 // @todo tests

--- a/packages/formik/src/Form.tsx
+++ b/packages/formik/src/Form.tsx
@@ -9,11 +9,9 @@ export type FormikFormProps = Pick<
   >
 >;
 
-type FormProps = React.ComponentPropsWithoutRef<'form'>;
-
 // @todo tests
-export const Form = React.forwardRef<HTMLFormElement, FormProps>(
-  (props: FormikFormProps, ref) => {
+export const Form = React.forwardRef<HTMLFormElement, FormikFormProps>(
+  (props, ref) => {
     // iOS needs an "action" attribute for nice input: https://stackoverflow.com/a/39485162/406725
     // We default the action to "#" in case the preventDefault fails (just updates the URL hash)
     const { action, ...rest } = props;


### PR DESCRIPTION
Closes #2120.

This is my first time pull requesting to a public repository, so please let me know about anything I might be doing wrong :smile: 

The primary purpose of this PR is to attempt to change the emitted type definition in `Form.d.ts`. 

Before this change, TS would end up inlining all 200+ form attributes that our current `@types/react` version exposes into the definition file, `translate` being one of them. These attributes are not necessarily the same for a user of the library because they depend on the version of `@types/react`, resulting in [this compiler error](https://github.com/jaredpalmer/formik/issues/2120).

EDIT: I have no idea _why_ the inferred type inlines all attributes but the new one doesn't.

After this change, the declaration file no longer contains these attributes.

Before:
```
export declare const Form: React.ForwardRefExoticComponent<
	Pick<
		React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>,
		"acceptCharset" | "action" | "autoComplete" | "encType" | "method" | "name" | "noValidate" | "target" |
		"defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | "suppressHydrationWarning" | "accessKey" |
		"className" | "contentEditable" | "contextMenu" | "dir" | "draggable" | "hidden" | "id" | "lang" | ... 200+
	> & React.RefAttributes<HTMLFormElement>
>;
```

After:
```
declare type FormWrapper = React.ForwardRefExoticComponent<
	React.PropsWithoutRef<FormikFormProps> & React.RefAttributes<HTMLFormElement>
>;

export declare const Form: FormWrapper;
```

Depending on what the intended behaviour is, [this change](https://github.com/jaredpalmer/formik/commit/5fd272944dbc68c5b2272a0af354f30f9a1c2a34) is potentially a breaking change and I'm happy to revert it. It removes `onSubmit` and `onReset` from the available Form props.

Finally, I left a comment in the code that tries to explain why we'd manually write the exact type that `forwardRef` returns because it's not really obvious without the `Form.d.ts` file. Obviously if we think this isn't useful, I'm happy to take it out.