### PR TITLE
fix: make execute blur safe when event is not provided

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -694,7 +694,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       if (e.persist) {
         e.persist();
       }
-      const { name, id, outerHTML } = e.target;
+      const { name, id, outerHTML } = e?.target ?? {};
       const field = path ? path : name ? name : id;
 
       if (!field && __DEV__) {

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -690,9 +690,15 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   );
 
   const executeBlur = React.useCallback(
-    (e: any, path?: string) => {
-      if (e.persist) {
-        e.persist();
+    (
+      e: null | {
+        persist: any;
+        target: { name: any; id: any; outerHTML: any };
+      },
+      path?: string
+    ) => {
+      if (e?.persist) {
+        e?.persist();
       }
       const { name, id, outerHTML } = e?.target ?? {};
       const field = path ? path : name ? name : id;
@@ -714,7 +720,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     | void
     | ((e: any) => void) => {
     if (isString(eventOrString)) {
-      return event => executeBlur(event, eventOrString);
+      return () => executeBlur(null, eventOrString);
     } else {
       executeBlur(eventOrString);
     }


### PR DESCRIPTION
Thanks for publishing such a great library 😊

## What

- Make `handleBlur` generate a function which does not need any argument if a field name is provided as an argument.
- Make `executeBlur` safe when an event (the first argument) is not provided

## Why

In `executeBlur` function, `e` (the first argument of this function) is not used when `path` (the second argument of this function) is provided. Nevertheless, this function causes a runtime error when the user executes `handleBlur` without any argument even though it does not need it!

## Backgorund

Some of the UI components provided form UI pattern library does not send a native event to a handler. Therefore, we need to specify the name of the field manually. In this case, this function no longer needs the event object.

In my case, [InputItem](https://rn.mobile.ant.design/components/input-item/) from Ant Design React Native does not pass an event object to the handler. So, I need to pass some dummy value to `handleBlur` like:

```tsx
<InputItem
  ...
  // onBlur cause same result in this case
  onEndEditing={() => handleBlur('username')({ target: { id: "", name: "", outerHTML: "" } })}
/>
```

This is annoying.
