### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/api/fastfield.md
+++ b/docs/api/fastfield.md
@@ -107,7 +107,7 @@ const Basic = () => (
            and all changes by all <Field>s and <FastField>s */}
           <label htmlFor="lastName">LastName</label>
           <Field name="lastName" placeholder="Baby">
-            {( }) => (
+            {({ field, form }) => (
               <div>
                 <input {...field} />
                 {/**  Works because this is inside


### PR DESCRIPTION
missing params in code block

-----
[View rendered docs/api/fastfield.md](https://github.com/ferricguy10101/formik/blob/patch-1/docs/api/fastfield.md)