### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/api/withFormik.md
+++ b/docs/api/withFormik.md
@@ -133,7 +133,7 @@ If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as
 `props.status`. Useful for storing or instantiating arbitrary state into your form. As a reminder, `status` will be reset to this initial value (and this function will be re-run) if the form is reset.
 
-### `mapPropsToTouched?: (props: Props) => FormikTocuhed<Values>`
+### `mapPropsToTouched?: (props: Props) => FormikTouched<Values>`
 
 If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as

--- a/website/versioned_docs/version-2.0.3/api/withFormik.md
+++ b/website/versioned_docs/version-2.0.3/api/withFormik.md
@@ -132,7 +132,7 @@ If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as
 `props.status`. Useful for storing or instantiating arbitrary state into your form. As a reminder, `status` will be reset to this initial value (and this function will be re-run) if the form is reset.
 
-### `mapPropsToTouched?: (props: Props) => FormikTocuhed<Values>`
+### `mapPropsToTouched?: (props: Props) => FormikTouched<Values>`
 
 If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as

--- a/website/versioned_docs/version-2.0.5/api/withFormik.md
+++ b/website/versioned_docs/version-2.0.5/api/withFormik.md
@@ -134,7 +134,7 @@ If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as
 `props.status`. Useful for storing or instantiating arbitrary state into your form. As a reminder, `status` will be reset to this initial value (and this function will be re-run) if the form is reset.
 
-### `mapPropsToTouched?: (props: Props) => FormikTocuhed<Values>`
+### `mapPropsToTouched?: (props: Props) => FormikTouched<Values>`
 
 If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as

--- a/website/versioned_docs/version-2.0.6/api/withFormik.md
+++ b/website/versioned_docs/version-2.0.6/api/withFormik.md
@@ -134,7 +134,7 @@ If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as
 `props.status`. Useful for storing or instantiating arbitrary state into your form. As a reminder, `status` will be reset to this initial value (and this function will be re-run) if the form is reset.
 
-### `mapPropsToTouched?: (props: Props) => FormikTocuhed<Values>`
+### `mapPropsToTouched?: (props: Props) => FormikTouched<Values>`
 
 If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as

--- a/website/versioned_docs/version-2.0.8/api/withFormik.md
+++ b/website/versioned_docs/version-2.0.8/api/withFormik.md
@@ -134,7 +134,7 @@ If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as
 `props.status`. Useful for storing or instantiating arbitrary state into your form. As a reminder, `status` will be reset to this initial value (and this function will be re-run) if the form is reset.
 
-### `mapPropsToTouched?: (props: Props) => FormikTocuhed<Values>`
+### `mapPropsToTouched?: (props: Props) => FormikTouched<Values>`
 
 If this option is specified, then Formik will transfer its results into
 updatable form state and make these values available to the new component as


### PR DESCRIPTION
```diff
- FormikTocuhed
+ FormikTouched
```

-----
[View rendered docs/api/withFormik.md](https://github.com/alexbassy/formik/blob/fix-typos/docs/api/withFormik.md)
[View rendered website/versioned_docs/version-2.0.3/api/withFormik.md](https://github.com/alexbassy/formik/blob/fix-typos/website/versioned_docs/version-2.0.3/api/withFormik.md)
[View rendered website/versioned_docs/version-2.0.5/api/withFormik.md](https://github.com/alexbassy/formik/blob/fix-typos/website/versioned_docs/version-2.0.5/api/withFormik.md)
[View rendered website/versioned_docs/version-2.0.6/api/withFormik.md](https://github.com/alexbassy/formik/blob/fix-typos/website/versioned_docs/version-2.0.6/api/withFormik.md)
[View rendered website/versioned_docs/version-2.0.8/api/withFormik.md](https://github.com/alexbassy/formik/blob/fix-typos/website/versioned_docs/version-2.0.8/api/withFormik.md)