### PR TITLE
Fix validateOnMount to validate even when initialValues is unchanged

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -364,6 +364,16 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     }
   );
 
+  React.useEffect(() => {
+    if (
+      validateOnMount &&
+      isMounted.current === true &&
+      isEqual(initialValues.current, props.initialValues)
+    ) {
+      validateFormWithLowPriority(initialValues.current);
+    }
+  }, [validateOnMount, validateFormWithLowPriority]);
+
   const resetForm = React.useCallback(
     (nextState?: Partial<FormikState<Values>>) => {
       const values =
@@ -433,16 +443,17 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   React.useEffect(() => {
     if (
-      enableReinitialize &&
       isMounted.current === true &&
       !isEqual(initialValues.current, props.initialValues)
     ) {
-      initialValues.current = props.initialValues;
-      resetForm();
-    }
+      if (enableReinitialize) {
+        initialValues.current = props.initialValues;
+        resetForm();
+      }
 
-    if (validateOnMount && isMounted.current === true) {
-      validateFormWithLowPriority(initialValues.current);
+      if (validateOnMount) {
+        validateFormWithLowPriority(initialValues.current);
+      }
     }
   }, [enableReinitialize, props.initialValues, resetForm, validateOnMount, validateFormWithLowPriority]);
 

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -433,18 +433,16 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   React.useEffect(() => {
     if (
+      enableReinitialize &&
       isMounted.current === true &&
       !isEqual(initialValues.current, props.initialValues)
     ) {
       initialValues.current = props.initialValues;
+      resetForm();
+    }
 
-      if (enableReinitialize) {
-        resetForm();
-      }
-
-      if (validateOnMount) {
-        validateFormWithLowPriority(initialValues.current);
-      }
+    if (validateOnMount && isMounted.current === true) {
+      validateFormWithLowPriority(initialValues.current);
     }
   }, [enableReinitialize, props.initialValues, resetForm, validateOnMount, validateFormWithLowPriority]);
 


### PR DESCRIPTION
Fixes #2624 

I moved the validation to happen outside of the statement checking for value reinitialization so that validation will run when Formik is remounted, even if initialValues don't change.