### PR TITLE
Docs: Remove placeholders from select fields in example

### DIFF
--- a/docs/src/pages/docs/api/field.md
+++ b/docs/src/pages/docs/api/field.md
@@ -134,7 +134,7 @@ Either JSX elements or callback function. Same as `render`.
 
 ```jsx
 // Children can be JSX elements
-<Field name="color" as="select" placeholder="Favorite Color">
+<Field name="color" as="select">
   <option value="red">Red</option>
   <option value="green">Green</option>
   <option value="blue">Blue</option>
@@ -172,7 +172,7 @@ Default is `'input'` (so an `<input>` is rendered by default)
 <Field name="lastName" placeholder="Last Name"/>
 
 // Renders an HTML <select>
-<Field name="color" component="select" placeholder="Favorite Color">
+<Field name="color" component="select">
   <option value="red">Red</option>
   <option value="green">Green</option>
   <option value="blue">Blue</option>


### PR DESCRIPTION
fix: #1996.
Docs incorrectly use placeholder attribute in Field component, so removing redundent placeholders.