### PR TITLE
Update DocSearch v3 implementation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.10.1",
-    "@docsearch/react": "1.0.0-alpha.14",
+    "@docsearch/react": "1.0.0-alpha.27",
+    "@docsearch/css": "1.0.0-alpha.27",
     "@mdx-js/loader": "^1.5.1",
     "@mdx-js/mdx": "^1.5.1",
     "@mdx-js/react": "^1.5.1",

--- a/docs/src/components/Sidebar.tsx
+++ b/docs/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ export const Sidebar: React.FC<{
       })}
     >
       <div className="sidebar-search my-2">
-        <Search renderModal={false} />
+        <Search />
       </div>
       <div className="sidebar-content overflow-y-auto pb-4">{children}</div>
       <style jsx>{`

--- a/docs/src/pages/_app.js
+++ b/docs/src/pages/_app.js
@@ -1,6 +1,5 @@
-import '@docsearch/react/dist/style.css';
+import '@docsearch/css';
 import '../styles/index.css';
-import '../components/FeedbackInput.css';
 import Head from 'next/head';
 
 function MyApp({ Component, pageProps }) {

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -79,7 +79,6 @@ h6:hover .anchor::after {
 
 /* Algolia v3 overrides */
 :root {
-  --docsearch-modal-background: #fff;
   --docsearch-highlight-color: #1965e0;
   --docsearch-primary-color: #0052cc;
   --docsearch-searchbox-shadow: 0 0 0 3px rgba(66, 153, 225, 0.5);


### PR DESCRIPTION
This updates the DocSearch v3 integration to the latest version:

- Support for typing query when the search button is focused
- Improved accessibility

The DocSearch integration on this website uses two instances: one for mobile, one for desktop. This resulted in a double modal being shown when hitting <kbd>Ctrl + K</kbd>, and then users has to click twice on the overlay to close it. I solved this by checking that no other DocSearch instance is showing before opening a new one. We might want to do this check in DocSearch itself in the future.