### PR TITLE
feat(utils): add support for parsing multiple yup validation errors

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -1066,7 +1066,7 @@ function warnAboutMissingIdentifier({
 /**
  * Transform Yup ValidationError to a more usable object
  */
-export function yupToFormErrors<Values>(yupError: any): FormikErrors<Values> {
+export function yupToFormErrors<Values>(yupError: any, concatErrors?: boolean): FormikErrors<Values> {
   let errors: FormikErrors<Values> = {};
   if (yupError.inner) {
     if (yupError.inner.length === 0) {
@@ -1074,7 +1074,7 @@ export function yupToFormErrors<Values>(yupError: any): FormikErrors<Values> {
     }
     for (let err of yupError.inner) {
       if (!getIn(errors, err.path)) {
-        errors = setIn(errors, err.path, err.message);
+        errors = setIn(errors, err.path, err.message, concatErrors);
       }
     }
   }

--- a/packages/formik/src/utils.ts
+++ b/packages/formik/src/utils.ts
@@ -103,7 +103,7 @@ export function getIn(
  * @see https://github.com/developit/linkstate
  * @see https://github.com/jaredpalmer/formik/pull/123
  */
-export function setIn(obj: any, path: string, value: any): any {
+export function setIn(obj: any, path: string, value: any, concatValues?: boolean): any {
   let res: any = clone(obj); // this keeps inheritance when obj is a class
   let resVal: any = res;
   let i = 0;
@@ -130,7 +130,9 @@ export function setIn(obj: any, path: string, value: any): any {
   if (value === undefined) {
     delete resVal[pathArray[i]];
   } else {
-    resVal[pathArray[i]] = value;
+    resVal[pathArray[i]] = (concatValues && resVal[pathArray[i]] !== undefined) 
+      ? [...obj[pathArray[i]], value] 
+      : value;
   }
 
   // If the path array has a single element, the loop did not run.

--- a/packages/formik/test/utils.test.tsx
+++ b/packages/formik/test/utils.test.tsx
@@ -267,6 +267,13 @@ describe('utils', () => {
       expect(newObj).toEqual({ x: 'y', nested: ['a', 'b'] });
     });
 
+    it('adds new item to array of arbitrary length', () => {
+      const obj = { x: 'y', nested: ['a'] };
+      const newObj = setIn(obj, 'nested', 'b', true);
+      expect(obj).toEqual({ x: 'y', nested: ['a'] });
+      expect(newObj).toEqual({ x: 'y', nested: ['a', 'b']});
+    });
+
     it('sticks to object with int key when defined', () => {
       const obj = { x: 'y', nested: { 0: 'a' } };
       const newObj = setIn(obj, 'nested.0', 'b');

--- a/packages/formik/test/yupHelpers.test.ts
+++ b/packages/formik/test/yupHelpers.test.ts
@@ -13,6 +13,19 @@ const nestedSchema = Yup.object().shape({
     ),
   }),
 });
+const multiSchema = Yup.object().shape({
+  field: Yup.number()
+  .test(
+    'Should be greater than zero',
+    'Field must be greater than zero',
+    (value: number) => value > 0
+  )
+  .test(
+    'Should be greater than five',
+    'Field must be greater than five',
+    (value: number) => value > 5
+  ),
+});
 
 describe('Yup helpers', () => {
   describe('yupToFormErrors()', () => {
@@ -25,6 +38,25 @@ describe('Yup helpers', () => {
         });
       }
     });
+
+    it('should transform multiple Yup ValidationErrors and preserve all values when specified', async () => {
+      let attempts = 0;
+      await multiSchema.validate({field: -1}, { abortEarly: false })
+      .then(() => {})
+      .catch((e: any) => {
+        if (attempts === 0) {
+          expect(yupToFormErrors(e, true)).toEqual({
+            field: 'Field must be greater than zero'
+          });
+        } else {
+          expect(yupToFormErrors(e, true)).toEqual({
+            field: ['Field must be greater than zero', 'Field must be greater than five']
+          });
+        }
+        attempts++;
+      })
+    });
+
   });
 
   describe('validateYupSchema()', () => {


### PR DESCRIPTION
## Changes

This adds optional behaviour to yupToFormErrors by allowing multiple errors to be parsed into form errors.

As setIn maintains the previous behaviour of overriding values when concatValues is either falsey or the corresponding value is undefined; this change will not break any dependencies relying on setIn's existing behaviour.

## Example

An example use case can be found **[here](https://github.com/jarrodli/formik/blob/3ef19248e955b5196e28d459b0fe75103e4ad6c6/packages/formik/test/yupHelpers.test.ts#L42)**.

## Why is this change needed?

In response to a need from both personal use and community forum, see **[this](https://github.com/formium/formik/issues/1864)** issue.
