### PR TITLE
Replace all instances of the deprecated React.SFC type with React.FC

### DIFF
--- a/.changeset/honest-llamas-brush.md
+++ b/.changeset/honest-llamas-brush.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+Replace all instances of the deprecated React.SFC type with React.FC

--- a/docs/src/components/clients/Filters.tsx
+++ b/docs/src/components/clients/Filters.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const Filters: React.SFC<{}> = () => (
+export const Filters: React.FC<{}> = () => (
   <>
     <svg width={0} height={0}>
       <defs>

--- a/docs/src/pages/docs/1.5.8/guides/typescript.md
+++ b/docs/src/pages/docs/1.5.8/guides/typescript.md
@@ -27,7 +27,7 @@ interface MyFormValues {
   firstName: string;
 }
 
-export const MyApp: React.SFC<{}> = () => {
+export const MyApp: React.FC<{}> = () => {
   return (
     <div>
       <h1>My Example</h1>

--- a/packages/formik/src/connect.tsx
+++ b/packages/formik/src/connect.tsx
@@ -12,7 +12,7 @@ import invariant from 'tiny-warning';
 export function connect<OuterProps, Values = {}>(
   Comp: React.ComponentType<OuterProps & { formik: FormikContextType<Values> }>
 ) {
-  const C: React.SFC<OuterProps> = (props: OuterProps) => (
+  const C: React.FC<OuterProps> = (props: OuterProps) => (
     <FormikConsumer>
       {formik => {
         invariant(
@@ -31,7 +31,7 @@ export function connect<OuterProps, Values = {}>(
 
   // Assign Comp to C.WrappedComponent so we can access the inner component in tests
   // For example, <Field.WrappedComponent /> gets us <FieldInner/>
-  (C as React.SFC<OuterProps> & {
+  (C as React.FC<OuterProps> & {
     WrappedComponent: React.ReactNode;
   }).WrappedComponent = Comp;
 

--- a/packages/formik/src/withFormik.tsx
+++ b/packages/formik/src/withFormik.tsx
@@ -20,7 +20,7 @@ import { isFunction } from './utils';
 export type InjectedFormikProps<Props, Values> = Props & FormikProps<Values>;
 
 /**
- * Formik actions + { props }
+ * Formik helpers + { props }
  */
 export type FormikBag<P, V> = { props: P } & FormikHelpers<V>;
 

--- a/packages/formik/test/ErrorMessage.test.tsx
+++ b/packages/formik/test/ErrorMessage.test.tsx
@@ -8,7 +8,7 @@ interface TestFormValues {
   email: string;
 }
 
-const TestForm: React.SFC<any> = p => (
+const TestForm: React.FC<any> = p => (
   <Formik
     onSubmit={noop}
     initialValues={{ name: 'jared', email: 'hello@reason.nyc' }}

--- a/packages/formik/test/FieldArray.test.tsx
+++ b/packages/formik/test/FieldArray.test.tsx
@@ -6,7 +6,7 @@ import { FieldArray, Formik, isFunction } from '../src';
 // tslint:disable-next-line:no-empty
 const noop = () => {};
 
-const TestForm: React.SFC<any> = p => (
+const TestForm: React.FC<any> = p => (
   <Formik
     onSubmit={noop}
     initialValues={{ friends: ['jared', 'andrea', 'brent'] }}

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -9,7 +9,7 @@ interface Values {
   name: string;
 }
 
-const Form: React.SFC<FormikProps<Values>> = ({
+const Form: React.FC<FormikProps<Values>> = ({
   values,
   handleSubmit,
   handleChange,


### PR DESCRIPTION
- Made a cosmetic change to check that changeset bot works and how this interacts with Kodiak bot
- Replaced all instances of the deprecated `React.SFC` type with `React.FC`	