### PR TITLE
Update react testing library

### DIFF
--- a/packages/formik/package.json
+++ b/packages/formik/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "16.9.4"
   },
   "devDependencies": {
+    "@testing-library/react": "^11.0.4",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/lodash": "^4.14.119",
     "@types/react": "^16.9.17",
@@ -56,7 +57,6 @@
     "just-debounce-it": "^1.1.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-testing-library": "^7.0.0",
     "yup": "^0.28.1"
   },
   "jest": {
@@ -67,7 +67,6 @@
       "src/**/*.{ts,tsx}"
     ],
     "setupFilesAfterEnv": [
-      "react-testing-library/cleanup-after-each.js",
       "<rootDir>/test/setupTests.ts"
     ]
   }

--- a/packages/formik/test/ErrorMessage.test.tsx
+++ b/packages/formik/test/ErrorMessage.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { act, render } from '@testing-library/react';
 import { Formik, FormikProps, ErrorMessage } from '../src';
 import { noop } from './testHelpers';
 
@@ -16,16 +16,12 @@ const TestForm: React.FC<any> = p => (
   />
 );
 
-describe('<ErrorMessage />', () => {
-  const node = document.createElement('div');
-  afterEach(() => {
-    ReactDOM.unmountComponentAtNode(node);
-  });
+fdescribe('<ErrorMessage />', () => {
   it('renders with children as a function', async () => {
     let actual: any; /** ErrorMessage ;) */
     let actualFProps: any;
     let message = 'Wrong';
-    ReactDOM.render(
+    render(
       <TestForm
         render={(fProps: FormikProps<TestFormValues>) => {
           actualFProps = fProps;
@@ -37,14 +33,20 @@ describe('<ErrorMessage />', () => {
             </div>
           );
         }}
-      />,
-      node
+      />
     );
 
-    actualFProps.setFieldError('email', message);
+    await act(async () => {
+      await actualFProps.setFieldError('email', message);
+    });
+
     // Only renders if Field has been visited.
     expect(actual).toEqual(undefined);
-    actualFProps.setFieldTouched('email');
+
+    await act(async () => {
+      await actualFProps.setFieldTouched('email');
+    });
+
     // Renders after being visited with an error.
     expect(actual).toEqual(message);
   });

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-// @ts-ignore
-import { act, cleanup, render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, cleanup, render, waitFor, fireEvent } from '@testing-library/react';
 import * as Yup from 'yup';
 import {
   Formik,
@@ -362,7 +361,11 @@ describe('Field / FastField', () => {
           component: 'input',
         });
         rerender();
-        getFormProps().validateField('name');
+
+        act(() => {
+          getFormProps().validateField('name');
+        })
+
         rerender();
         await waitFor(() => {
           expect(validate).toHaveBeenCalled();
@@ -381,7 +384,9 @@ describe('Field / FastField', () => {
         // workaround for `useEffect` to run: https://github.com/facebook/react/issues/14050
         rerender();
 
-        getFormProps().validateField('name');
+        act(() => {
+          getFormProps().validateField('name');
+        })
 
         expect(validate).toHaveBeenCalled();
         await waitFor(() => expect(getFormProps().errors.name).toBe('Error!'));
@@ -403,7 +408,9 @@ describe('Field / FastField', () => {
 
         rerender();
 
-        getFormProps().validateField('name');
+        act(() => {
+          getFormProps().validateField('name');
+        })
 
         await waitFor(() =>
           expect(getFormProps().errors).toEqual({

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { cleanup, render, wait, fireEvent } from 'react-testing-library';
+// @ts-ignore
+import { act, cleanup, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import * as Yup from 'yup';
 import {
   Formik,
@@ -82,8 +83,8 @@ function cases(
   tester: (arg: typeof renderField | typeof renderFastField) => void
 ) {
   describe(title, () => {
-    it('<FastField />', async () => Promise.resolve(tester(renderFastField)));
-    it('<Field />', async () => Promise.resolve(tester(renderField)));
+    it('<FastField />', async () => await tester(renderFastField));
+    it('<Field />', async () => await tester(renderField));
   });
 }
 
@@ -293,7 +294,7 @@ describe('Field / FastField', () => {
       });
 
       rerender();
-      await wait(() => {
+      await waitFor(() => {
         expect(validate).toHaveBeenCalled();
       });
     });
@@ -311,7 +312,7 @@ describe('Field / FastField', () => {
           target: { name: 'name', value: 'hello' },
         });
         rerender();
-        await wait(() => {
+        await waitFor(() => {
           expect(validate).not.toHaveBeenCalled();
         });
       }
@@ -328,7 +329,7 @@ describe('Field / FastField', () => {
         target: { name: 'name' },
       });
       rerender();
-      await wait(() => {
+      await waitFor(() => {
         expect(validate).toHaveBeenCalled();
       });
     });
@@ -348,7 +349,7 @@ describe('Field / FastField', () => {
         });
         rerender();
 
-        await wait(() => expect(validate).not.toHaveBeenCalled());
+        await waitFor(() => expect(validate).not.toHaveBeenCalled());
       }
     );
 
@@ -363,7 +364,7 @@ describe('Field / FastField', () => {
         rerender();
         getFormProps().validateField('name');
         rerender();
-        await wait(() => {
+        await waitFor(() => {
           expect(validate).toHaveBeenCalled();
           expect(getFormProps().errors.name).toBe('Error!');
         });
@@ -383,7 +384,7 @@ describe('Field / FastField', () => {
         getFormProps().validateField('name');
 
         expect(validate).toHaveBeenCalled();
-        await wait(() => expect(getFormProps().errors.name).toBe('Error!'));
+        await waitFor(() => expect(getFormProps().errors.name).toBe('Error!'));
       }
     );
 
@@ -404,7 +405,7 @@ describe('Field / FastField', () => {
 
         getFormProps().validateField('name');
 
-        await wait(() =>
+        await waitFor(() =>
           expect(getFormProps().errors).toEqual({
             name: errorMessage,
           })

--- a/packages/formik/test/FieldArray.test.tsx
+++ b/packages/formik/test/FieldArray.test.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { FieldArray, Formik, isFunction } from '../src';
 
-// tslint:disable-next-line:no-empty
 const noop = () => {};
 
 const TestForm: React.FC<any> = p => (
@@ -15,30 +14,23 @@ const TestForm: React.FC<any> = p => (
 );
 
 describe('<FieldArray />', () => {
-  const node = document.createElement('div');
-
-  afterEach(() => {
-    ReactDOM.unmountComponentAtNode(node);
-  });
-
   it('renders component with array helpers as props', () => {
     const TestComponent = (arrayProps: any) => {
       expect(isFunction(arrayProps.push)).toBeTruthy();
       return null;
     };
 
-    ReactDOM.render(
+    render(
       <TestForm
         component={() => (
           <FieldArray name="friends" component={TestComponent} />
         )}
-      />,
-      node
+      />
     );
   });
 
   it('renders with render callback with array helpers as props', () => {
-    ReactDOM.render(
+    render(
       <TestForm>
         {() => (
           <FieldArray
@@ -49,13 +41,12 @@ describe('<FieldArray />', () => {
             }}
           />
         )}
-      </TestForm>,
-      node
+      </TestForm>
     );
   });
 
   it('renders with "children as a function" with array helpers as props', () => {
-    ReactDOM.render(
+    render(
       <TestForm>
         {() => (
           <FieldArray name="friends">
@@ -65,13 +56,12 @@ describe('<FieldArray />', () => {
             }}
           </FieldArray>
         )}
-      </TestForm>,
-      node
+      </TestForm>
     );
   });
 
   it('renders with name as props', () => {
-    ReactDOM.render(
+    render(
       <TestForm>
         {() => (
           <FieldArray
@@ -82,8 +72,7 @@ describe('<FieldArray />', () => {
             }}
           />
         )}
-      </TestForm>,
-      node
+      </TestForm>
     );
   });
 
@@ -91,7 +80,7 @@ describe('<FieldArray />', () => {
     it('should add a value to the end of the field array', () => {
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
@@ -105,18 +94,19 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      arrayHelpers.push('jared');
+      act(() => {
+        arrayHelpers.push('jared');
+      });
+
       const expected = ['jared', 'andrea', 'brent', 'jared'];
       expect(formikBag.values.friends).toEqual(expected);
     });
 
     it('should add multiple values to the end of the field array', () => {
       let formikBag: any;
-      let addFriendsFn: any;
       const AddFriendsButton = (arrayProps: any) => {
         const addFriends = () => {
           arrayProps.push('john');
@@ -125,22 +115,29 @@ describe('<FieldArray />', () => {
           arrayProps.push('ringo');
         };
 
-        addFriendsFn = addFriends;
-
-        return <button type="button" onClick={addFriends} />;
+        return (
+          <button
+            data-testid="add-friends-button"
+            type="button"
+            onClick={addFriends}
+          />
+        );
       };
 
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
             return <FieldArray name="friends" render={AddFriendsButton} />;
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      addFriendsFn();
+      act(() => {
+        const btn = screen.getByTestId('add-friends-button');
+        fireEvent.click(btn);
+      });
+
       const expected = [
         'jared',
         'andrea',
@@ -153,11 +150,11 @@ describe('<FieldArray />', () => {
       expect(formikBag.values.friends).toEqual(expected);
     });
 
-    it('should push clone not actual referance', () => {
+    it('should push clone not actual reference', () => {
       let personTemplate = { firstName: '', lastName: '' };
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
+      render(
         <TestForm initialValues={{ people: [] }}>
           {(props: any) => {
             formikBag = props;
@@ -171,11 +168,12 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      arrayHelpers.push(personTemplate);
+      act(() => {
+        arrayHelpers.push(personTemplate);
+      });
       expect(
         formikBag.values.people[formikBag.values.people.length - 1]
       ).not.toBe(personTemplate);
@@ -189,7 +187,7 @@ describe('<FieldArray />', () => {
     it('should remove and return the last value from the field array', () => {
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
@@ -203,14 +201,15 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      const el = arrayHelpers.pop();
+      act(() => {
+        const el = arrayHelpers.pop();
+        expect(el).toEqual('brent');
+      });
       const expected = ['jared', 'andrea'];
       expect(formikBag.values.friends).toEqual(expected);
-      expect(el).toEqual('brent');
     });
   });
 
@@ -218,7 +217,7 @@ describe('<FieldArray />', () => {
     it('should swap two values in field array', () => {
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
@@ -232,11 +231,12 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      arrayHelpers.swap(0, 2);
+      act(() => {
+        arrayHelpers.swap(0, 2);
+      });
       const expected = ['brent', 'andrea', 'jared'];
       expect(formikBag.values.friends).toEqual(expected);
     });
@@ -246,7 +246,7 @@ describe('<FieldArray />', () => {
     it('should insert a value at given index of field array', () => {
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
@@ -260,11 +260,12 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      arrayHelpers.insert(1, 'brian');
+      act(() => {
+        arrayHelpers.insert(1, 'brian');
+      });
       const expected = ['jared', 'brian', 'andrea', 'brent'];
       expect(formikBag.values.friends).toEqual(expected);
     });
@@ -274,7 +275,7 @@ describe('<FieldArray />', () => {
     it('should replace a value at given index of field array', () => {
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
@@ -288,11 +289,12 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      arrayHelpers.replace(1, 'brian');
+      act(() => {
+        arrayHelpers.replace(1, 'brian');
+      });
       const expected = ['jared', 'brian', 'brent'];
       expect(formikBag.values.friends).toEqual(expected);
     });
@@ -302,7 +304,7 @@ describe('<FieldArray />', () => {
     it('should add a value to start of field array and return its length', () => {
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
@@ -316,11 +318,13 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
 
-      const el = arrayHelpers.unshift('brian');
+      let el: any;
+      act(() => {
+        el = arrayHelpers.unshift('brian');
+      });
       const expected = ['brian', 'jared', 'andrea', 'brent'];
       expect(formikBag.values.friends).toEqual(expected);
       expect(el).toEqual(4);
@@ -332,7 +336,7 @@ describe('<FieldArray />', () => {
     let arrayHelpers: any;
 
     beforeEach(() => {
-      ReactDOM.render(
+      render(
         <TestForm>
           {(props: any) => {
             formikBag = props;
@@ -346,29 +350,34 @@ describe('<FieldArray />', () => {
               />
             );
           }}
-        </TestForm>,
-        node
+        </TestForm>
       );
     });
     it('should remove a value at given index of field array', () => {
-      arrayHelpers.remove(1);
+      act(() => {
+        arrayHelpers.remove(1);
+      });
       const expected = ['jared', 'brent'];
       expect(formikBag.values.friends).toEqual(expected);
     });
 
     it('should be an empty array when removing all values', () => {
-      arrayHelpers.remove(0);
-      arrayHelpers.remove(0);
-      arrayHelpers.remove(0);
+      act(() => {
+        arrayHelpers.remove(0);
+        arrayHelpers.remove(0);
+        arrayHelpers.remove(0);
+      });
       const expected: any[] = [];
 
       expect(formikBag.values.friends).toEqual(expected);
     });
     it('should clean field from errors and touched', () => {
-      // seems weird calling 0 multiple times, but every time we call remove, the indexes get updated.
-      arrayHelpers.remove(0);
-      arrayHelpers.remove(0);
-      arrayHelpers.remove(0);
+      act(() => {
+        // seems weird calling 0 multiple times, but every time we call remove, the indexes get updated.
+        arrayHelpers.remove(0);
+        arrayHelpers.remove(0);
+        arrayHelpers.remove(0);
+      });
 
       expect(formikBag.errors.friends).toEqual(undefined);
       expect(formikBag.touched.friends).toEqual(undefined);
@@ -376,40 +385,43 @@ describe('<FieldArray />', () => {
   });
 
   describe('given array-like object representing errors', () => {
-    it('should run arrayHelpers successfully', () => {
+    it('should run arrayHelpers successfully', async () => {
       let formikBag: any;
       let arrayHelpers: any;
-      ReactDOM.render(
-        <TestForm
-          render={(props: any) => {
+      render(
+        <TestForm>
+          {(props: any) => {
             formikBag = props;
             return (
-              <FieldArray
-                name="friends"
-                render={arrayProps => {
+              <FieldArray name="friends">
+                {arrayProps => {
                   arrayHelpers = arrayProps;
                   return null;
                 }}
-              />
+              </FieldArray>
             );
           }}
-        />,
-        node
+        </TestForm>
       );
 
-      formikBag.setErrors({ friends: { 2: ['Field error'] } });
+      act(() => {
+        formikBag.setErrors({ friends: { 2: ['Field error'] } });
+      });
 
-      arrayHelpers.push('michael');
-      const el = arrayHelpers.pop();
-      arrayHelpers.swap(0, 2);
-      arrayHelpers.insert(1, 'michael');
-      arrayHelpers.replace(1, 'brian');
-      arrayHelpers.unshift('michael');
-      arrayHelpers.remove(1);
+      let el: any;
+      await act(async () => {
+        await arrayHelpers.push('michael');
+        el = arrayHelpers.pop();
+        arrayHelpers.swap(0, 2);
+        arrayHelpers.insert(1, 'michael');
+        arrayHelpers.replace(1, 'brian');
+        arrayHelpers.unshift('michael');
+        arrayHelpers.remove(1);
+      });
 
-      const expected = ['michael', 'brian', 'andrea', 'jared'];
       expect(el).toEqual('michael');
-      expect(formikBag.values.friends).toEqual(expected);
+      const finalExpected = ['michael', 'brian', 'andrea', 'jared'];
+      expect(formikBag.values.friends).toEqual(finalExpected);
     });
   });
 });

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react';
-import { render, fireEvent, wait } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import * as Yup from 'yup';
 
 import {
   Formik,
-  prepareDataForValidation,
-  FormikProps,
   FormikConfig,
+  FormikProps,
+  prepareDataForValidation,
 } from '../src';
 import { noop } from './testHelpers';
 
@@ -172,7 +178,7 @@ describe('<Formik>', () => {
 
     it('updates values when passed a string (overloaded)', () => {
       let injected: any;
-      const { getByTestId } = render(
+      render(
         <Formik initialValues={InitialValues} onSubmit={noop}>
           {formikProps =>
             (injected = formikProps) && (
@@ -184,7 +190,7 @@ describe('<Formik>', () => {
           }
         </Formik>
       );
-      const input = getByTestId('name-input');
+      const input = screen.getByTestId('name-input');
 
       expect(injected.values.name).toEqual('jared');
       fireEvent.change(input, {
@@ -202,12 +208,12 @@ describe('<Formik>', () => {
       const validationSchema = {
         validate,
       };
-      const { getByTestId, rerender } = renderFormik({
+      const { rerender } = renderFormik({
         validate,
         validationSchema,
       });
 
-      fireEvent.change(getByTestId('name-input'), {
+      fireEvent.change(screen.getByTestId('name-input'), {
         persist: noop,
         target: {
           name: 'name',
@@ -215,7 +221,7 @@ describe('<Formik>', () => {
         },
       });
       rerender();
-      await wait(() => {
+      await waitFor(() => {
         expect(validate).toHaveBeenCalledTimes(2);
       });
     });
@@ -225,13 +231,13 @@ describe('<Formik>', () => {
       const validationSchema = {
         validate,
       };
-      const { getByTestId, rerender } = renderFormik({
+      const { rerender } = renderFormik({
         validate,
         validationSchema,
         validateOnChange: false,
       });
 
-      fireEvent.change(getByTestId('name-input'), {
+      fireEvent.change(screen.getByTestId('name-input'), {
         persist: noop,
         target: {
           name: 'name',
@@ -239,7 +245,7 @@ describe('<Formik>', () => {
         },
       });
       rerender();
-      await wait(() => {
+      await waitFor(() => {
         expect(validate).not.toHaveBeenCalled();
       });
     });
@@ -247,10 +253,10 @@ describe('<Formik>', () => {
 
   describe('handleBlur', () => {
     it('sets touched state', () => {
-      const { getProps, getByTestId } = renderFormik<Values>();
+      const { getProps } = renderFormik<Values>();
       expect(getProps().touched.name).toEqual(undefined);
 
-      const input = getByTestId('name-input');
+      const input = screen.getByTestId('name-input');
       fireEvent.blur(input, {
         target: {
           name: 'name',
@@ -260,10 +266,10 @@ describe('<Formik>', () => {
     });
 
     it('updates touched state via `name` instead of `id` attribute when both are present', () => {
-      const { getProps, getByTestId } = renderFormik<Values>();
+      const { getProps } = renderFormik<Values>();
       expect(getProps().touched.name).toEqual(undefined);
 
-      const input = getByTestId('name-input');
+      const input = screen.getByTestId('name-input');
       fireEvent.blur(input, {
         target: {
           id: 'blah',
@@ -275,7 +281,7 @@ describe('<Formik>', () => {
 
     it('updates touched when passed a string (overloaded)', () => {
       let injected: any;
-      const { getByTestId } = render(
+      render(
         <Formik initialValues={InitialValues} onSubmit={noop}>
           {formikProps =>
             (injected = formikProps) && (
@@ -287,7 +293,7 @@ describe('<Formik>', () => {
           }
         </Formik>
       );
-      const input = getByTestId('name-input');
+      const input = screen.getByTestId('name-input');
 
       expect(injected.touched.name).toEqual(undefined);
       fireEvent.blur(input, {
@@ -302,15 +308,15 @@ describe('<Formik>', () => {
 
     it('runs validate by default', async () => {
       const validate = jest.fn(noop);
-      const { getByTestId, rerender } = renderFormik({ validate });
+      const { rerender } = renderFormik({ validate });
 
-      fireEvent.blur(getByTestId('name-input'), {
+      fireEvent.blur(screen.getByTestId('name-input'), {
         target: {
           name: 'name',
         },
       });
       rerender();
-      await wait(() => {
+      await waitFor(() => {
         expect(validate).toHaveBeenCalled();
       });
     });
@@ -320,18 +326,18 @@ describe('<Formik>', () => {
       const validationSchema = {
         validate,
       };
-      const { getByTestId, rerender } = renderFormik({
+      const { rerender } = renderFormik({
         validate,
         validationSchema,
       });
 
-      fireEvent.blur(getByTestId('name-input'), {
+      fireEvent.blur(screen.getByTestId('name-input'), {
         target: {
           name: 'name',
         },
       });
       rerender();
-      await wait(() => {
+      await waitFor(() => {
         expect(validate).toHaveBeenCalledTimes(2);
       });
     });
@@ -341,18 +347,18 @@ describe('<Formik>', () => {
       const validationSchema = {
         validate,
       };
-      const { getByTestId, rerender } = renderFormik({
+      const { rerender } = renderFormik({
         validate,
         validationSchema,
       });
 
-      fireEvent.blur(getByTestId('name-input'), {
+      fireEvent.blur(screen.getByTestId('name-input'), {
         target: {
           name: 'name',
         },
       });
       rerender();
-      await wait(() => {
+      await waitFor(() => {
         expect(validate).toHaveBeenCalledTimes(2);
       });
     });
@@ -368,7 +374,7 @@ describe('<Formik>', () => {
         validateOnBlur: false,
       });
       rerender();
-      await wait(() => expect(validate).not.toHaveBeenCalled());
+      await waitFor(() => expect(validate).not.toHaveBeenCalled());
     });
   });
 
@@ -386,8 +392,8 @@ describe('<Formik>', () => {
         </Formik>
       );
 
-      const { getByTestId } = render(FormPreventDefault);
-      fireEvent.click(getByTestId('submit-button'));
+      render(FormPreventDefault);
+      fireEvent.click(screen.getByTestId('submit-button'));
 
       expect(preventDefault).toHaveBeenCalled();
     });
@@ -405,10 +411,11 @@ describe('<Formik>', () => {
           )}
         </Formik>
       );
-      const { getByTestId } = render(FormNoEvent);
+
+      render(FormNoEvent);
 
       expect(() => {
-        fireEvent.click(getByTestId('submit-button'));
+        fireEvent.click(screen.getByTestId('submit-button'));
       }).not.toThrow();
     });
 
@@ -423,10 +430,11 @@ describe('<Formik>', () => {
           )}
         </Formik>
       );
-      const { getByTestId } = render(FormNoPreventDefault);
+
+      render(FormNoPreventDefault);
 
       expect(() => {
-        fireEvent.click(getByTestId('submit-button'));
+        fireEvent.click(screen.getByTestId('submit-button'));
       }).not.toThrow();
     });
 
@@ -446,18 +454,19 @@ describe('<Formik>', () => {
           )}
         </Formik>
       );
-      const { getByTestId } = render(FormNoPreventDefault);
+
+      render(FormNoPreventDefault);
 
       expect(() => {
-        fireEvent.click(getByTestId('submit-button'));
+        fireEvent.click(screen.getByTestId('submit-button'));
       }).not.toThrow();
     });
 
     it('should touch all fields', () => {
-      const { getProps, getByTestId } = renderFormik();
+      const { getProps } = renderFormik();
       expect(getProps().touched).toEqual({});
 
-      fireEvent.submit(getByTestId('form'));
+      fireEvent.submit(screen.getByTestId('form'));
       expect(getProps().touched).toEqual({ name: true, age: true });
     });
 
@@ -483,7 +492,7 @@ describe('<Formik>', () => {
         const { getByTestId } = renderFormik({ onSubmit, validate });
 
         fireEvent.submit(getByTestId('form'));
-        await wait(() => expect(onSubmit).toBeCalled());
+        await waitFor(() => expect(onSubmit).toBeCalled());
       });
 
       it('should not submit the form if invalid', () => {
@@ -504,9 +513,11 @@ describe('<Formik>', () => {
           validate,
         });
 
-        await expect(getProps().submitForm()).rejects.toThrow('Async Error');
+        await act(async () => {
+          await expect(getProps().submitForm()).rejects.toThrow('Async Error');
+        });
 
-        await wait(() => {
+        await waitFor(() => {
           expect(onSubmit).not.toBeCalled();
           expect(global.console.warn).toHaveBeenCalledWith(
             expect.stringMatching(
@@ -526,7 +537,9 @@ describe('<Formik>', () => {
           const { getProps } = renderFormik({ onSubmit: handleSubmit });
 
           const { submitForm } = getProps();
-          await expect(submitForm()).rejects.toEqual(error);
+          await act(async () => {
+            await expect(submitForm()).rejects.toEqual(error);
+          });
         });
       });
     });
@@ -546,7 +559,7 @@ describe('<Formik>', () => {
         const { getByTestId } = renderFormik({ onSubmit, validate });
 
         fireEvent.submit(getByTestId('form'));
-        await wait(() => expect(onSubmit).toBeCalled());
+        await waitFor(() => expect(onSubmit).toBeCalled());
       });
 
       it('should not submit the form if invalid', () => {
@@ -565,9 +578,11 @@ describe('<Formik>', () => {
 
         const { getProps } = renderFormik({ onSubmit, validate });
 
-        await expect(getProps().submitForm()).rejects.toThrow('Async Error');
+        await act(async () => {
+          await expect(getProps().submitForm()).rejects.toThrow('Async Error');
+        });
 
-        await wait(() => {
+        await waitFor(() => {
           expect(onSubmit).not.toBeCalled();
           expect(global.console.warn).toHaveBeenCalledWith(
             expect.stringMatching(
@@ -585,12 +600,15 @@ describe('<Formik>', () => {
         const validationSchema = {
           validate,
         };
-        const { getByTestId } = renderFormik({
+        renderFormik({
           validate,
           validationSchema,
         });
 
-        fireEvent.submit(getByTestId('form'));
+        await act(async () => {
+          await fireEvent.submit(screen.getByTestId('form'));
+        });
+
         expect(validate).toHaveBeenCalled();
       });
 
@@ -599,12 +617,14 @@ describe('<Formik>', () => {
         const validationSchema = () => ({
           validate,
         });
-        const { getByTestId } = renderFormik({
+        renderFormik({
           validate,
           validationSchema,
         });
 
-        fireEvent.submit(getByTestId('form'));
+        await act(async () => {
+          await fireEvent.submit(screen.getByTestId('form'));
+        });
         expect(validate).toHaveBeenCalled();
       });
     });
@@ -613,7 +633,9 @@ describe('<Formik>', () => {
       it('setValues sets values', () => {
         const { getProps } = renderFormik<Values>();
 
-        getProps().setValues({ name: 'ian', age: 25 });
+        act(() => {
+          getProps().setValues({ name: 'ian', age: 25 });
+        });
         expect(getProps().values.name).toEqual('ian');
         expect(getProps().values.age).toEqual(25);
       });
@@ -621,10 +643,12 @@ describe('<Formik>', () => {
       it('setValues takes a function which can patch values', () => {
         const { getProps } = renderFormik<Values>();
 
-        getProps().setValues((values: Values) => ({
-          ...values,
-          age: 80,
-        }));
+        act(() => {
+          getProps().setValues((values: Values) => ({
+            ...values,
+            age: 80,
+          }));
+        });
         expect(getProps().values.name).toEqual('jared');
         expect(getProps().values.age).toEqual(80);
       });
@@ -632,12 +656,13 @@ describe('<Formik>', () => {
       it('setValues should run validations when validateOnChange is true (default)', async () => {
         const newValue: Values = { name: 'ian' };
         const validate = jest.fn(_values => ({}));
-        // const { getProps, rerender } = renderFormik({ validate });
         const { getProps } = renderFormik({ validate });
 
-        getProps().setValues(newValue);
+        act(() => {
+          getProps().setValues(newValue);
+        });
         // rerender();
-        await wait(() => {
+        await waitFor(() => {
           expect(validate).toHaveBeenCalledWith(newValue, undefined);
         });
       });
@@ -648,9 +673,11 @@ describe('<Formik>', () => {
           validateOnChange: false,
         });
 
-        getProps().setValues({ name: 'ian' });
+        act(() => {
+          getProps().setValues({ name: 'ian' });
+        });
         rerender();
-        await wait(() => {
+        await waitFor(() => {
           expect(validate).not.toHaveBeenCalled();
         });
       });
@@ -658,9 +685,11 @@ describe('<Formik>', () => {
       it('setFieldValue sets value by key', async () => {
         const { getProps, rerender } = renderFormik<Values>();
 
-        getProps().setFieldValue('name', 'ian');
+        act(() => {
+          getProps().setFieldValue('name', 'ian');
+        });
         rerender();
-        await wait(() => {
+        await waitFor(() => {
           expect(getProps().values.name).toEqual('ian');
         });
       });
@@ -669,9 +698,11 @@ describe('<Formik>', () => {
         const validate = jest.fn(() => ({}));
         const { getProps, rerender } = renderFormik({ validate });
 
-        getProps().setFieldValue('name', 'ian');
+        act(() => {
+          getProps().setFieldValue('name', 'ian');
+        });
         rerender();
-        await wait(() => {
+        await waitFor(() => {
           expect(validate).toHaveBeenCalled();
         });
       });
@@ -683,9 +714,11 @@ describe('<Formik>', () => {
           validateOnChange: false,
         });
 
-        getProps().setFieldValue('name', 'ian');
+        act(() => {
+          getProps().setFieldValue('name', 'ian');
+        });
         rerender();
-        await wait(() => {
+        await waitFor(() => {
           expect(validate).not.toHaveBeenCalled();
         });
       });
@@ -693,7 +726,9 @@ describe('<Formik>', () => {
       it('setTouched sets touched', () => {
         const { getProps } = renderFormik();
 
-        getProps().setTouched({ name: true });
+        act(() => {
+          getProps().setTouched({ name: true });
+        });
         expect(getProps().touched).toEqual({ name: true });
       });
 
@@ -701,9 +736,11 @@ describe('<Formik>', () => {
         const validate = jest.fn(() => ({}));
         const { getProps, rerender } = renderFormik({ validate });
 
-        getProps().setTouched({ name: true });
+        act(() => {
+          getProps().setTouched({ name: true });
+        });
         rerender();
-        await wait(() => expect(validate).toHaveBeenCalled());
+        await waitFor(() => expect(validate).toHaveBeenCalled());
       });
 
       it('setTouched should run validations when validateOnBlur is false', async () => {
@@ -713,19 +750,25 @@ describe('<Formik>', () => {
           validateOnBlur: false,
         });
 
-        getProps().setTouched({ name: true });
+        act(() => {
+          getProps().setTouched({ name: true });
+        });
         rerender();
-        await wait(() => expect(validate).not.toHaveBeenCalled());
+        await waitFor(() => expect(validate).not.toHaveBeenCalled());
       });
 
       it('setFieldTouched sets touched by key', () => {
         const { getProps } = renderFormik<Values>();
 
-        getProps().setFieldTouched('name', true);
+        act(() => {
+          getProps().setFieldTouched('name', true);
+        });
         expect(getProps().touched).toEqual({ name: true });
         expect(getProps().dirty).toBe(false);
 
-        getProps().setFieldTouched('name', false);
+        act(() => {
+          getProps().setFieldTouched('name', false);
+        });
         expect(getProps().touched).toEqual({ name: false });
         expect(getProps().dirty).toBe(false);
       });
@@ -734,9 +777,11 @@ describe('<Formik>', () => {
         const validate = jest.fn(() => ({}));
         const { getProps, rerender } = renderFormik({ validate });
 
-        getProps().setFieldTouched('name', true);
+        act(() => {
+          getProps().setFieldTouched('name', true);
+        });
         rerender();
-        await wait(() => expect(validate).toHaveBeenCalled());
+        await waitFor(() => expect(validate).toHaveBeenCalled());
       });
 
       it('setFieldTouched should NOT run validations when validateOnBlur is false', async () => {
@@ -746,22 +791,28 @@ describe('<Formik>', () => {
           validateOnBlur: false,
         });
 
-        getProps().setFieldTouched('name', true);
+        act(() => {
+          getProps().setFieldTouched('name', true);
+        });
         rerender();
-        await wait(() => expect(validate).not.toHaveBeenCalled());
+        await waitFor(() => expect(validate).not.toHaveBeenCalled());
       });
 
       it('setErrors sets error object', () => {
         const { getProps } = renderFormik<Values>();
 
-        getProps().setErrors({ name: 'Required' });
+        act(() => {
+          getProps().setErrors({ name: 'Required' });
+        });
         expect(getProps().errors.name).toEqual('Required');
       });
 
       it('setFieldError sets error by key', () => {
         const { getProps } = renderFormik<Values>();
 
-        getProps().setFieldError('name', 'Required');
+        act(() => {
+          getProps().setFieldError('name', 'Required');
+        });
         expect(getProps().errors.name).toEqual('Required');
       });
 
@@ -769,7 +820,9 @@ describe('<Formik>', () => {
         const { getProps } = renderFormik();
 
         const status = 'status';
-        getProps().setStatus(status);
+        act(() => {
+          getProps().setStatus(status);
+        });
 
         expect(getProps().status).toEqual(status);
       });
@@ -781,7 +834,9 @@ describe('<Formik>', () => {
       const { getProps } = renderFormik();
 
       expect(getProps().dirty).toBeFalsy();
-      getProps().setValues({ name: 'ian', age: 27 });
+      act(() => {
+        getProps().setValues({ name: 'ian', age: 27 });
+      });
       expect(getProps().dirty).toBeTruthy();
     });
 
@@ -816,8 +871,10 @@ describe('<Formik>', () => {
     it('should compute isValid if the form is dirty and there are errors', () => {
       const { getProps } = renderFormik();
 
-      getProps().setValues({ name: 'ian' });
-      getProps().setErrors({ name: 'Required!' });
+      act(() => {
+        getProps().setValues({ name: 'ian' });
+        getProps().setErrors({ name: 'Required!' });
+      });
 
       expect(getProps().dirty).toBeTruthy();
       expect(getProps().isValid).toBeFalsy();
@@ -826,7 +883,9 @@ describe('<Formik>', () => {
     it('should compute isValid if the form is dirty and there are not errors', () => {
       const { getProps } = renderFormik();
 
-      getProps().setValues({ name: 'ian' });
+      act(() => {
+        getProps().setValues({ name: 'ian' });
+      });
 
       expect(getProps().dirty).toBeTruthy();
       expect(getProps().isValid).toBeTruthy();
@@ -851,7 +910,9 @@ describe('<Formik>', () => {
       });
 
       const { handleReset } = getProps();
-      handleReset();
+      act(() => {
+        handleReset();
+      });
 
       expect(onReset).toHaveBeenCalled();
     });
@@ -866,7 +927,9 @@ describe('<Formik>', () => {
         onReset,
       });
 
-      getProps().resetForm();
+      act(() => {
+        getProps().resetForm();
+      });
 
       expect(onReset).toHaveBeenCalledWith(
         InitialValues,
@@ -886,7 +949,9 @@ describe('<Formik>', () => {
 
     it('should not error resetting form if onReset is not a prop', () => {
       const { getProps } = renderFormik();
-      getProps().resetForm();
+      act(() => {
+        getProps().resetForm();
+      });
       expect(true);
     });
 
@@ -905,17 +970,23 @@ describe('<Formik>', () => {
       });
       expect(getProps().dirty).toBeTruthy();
 
-      getProps().resetForm();
+      act(() => {
+        getProps().resetForm();
+      });
       expect(getProps().dirty).toBeFalsy();
     });
 
     it('should reset submitCount', () => {
       const { getProps } = renderFormik();
 
-      getProps().handleSubmit();
+      act(() => {
+        getProps().handleSubmit();
+      });
       expect(getProps().submitCount).toEqual(1);
 
-      getProps().resetForm();
+      act(() => {
+        getProps().resetForm();
+      });
       expect(getProps().submitCount).toEqual(0);
     });
 
@@ -923,10 +994,14 @@ describe('<Formik>', () => {
       const { getProps } = renderFormik();
       expect(getProps().dirty).toBe(false);
 
-      getProps().setFieldValue('name', 'jared-next');
+      act(() => {
+        getProps().setFieldValue('name', 'jared-next');
+      });
       expect(getProps().dirty).toBe(true);
 
-      getProps().resetForm({ values: getProps().values });
+      act(() => {
+        getProps().resetForm({ values: getProps().values });
+      });
       expect(getProps().dirty).toBe(false);
     });
   });
@@ -934,6 +1009,7 @@ describe('<Formik>', () => {
   describe('prepareDataForValidation', () => {
     it('should work correctly with instances', () => {
       class SomeClass {}
+
       const expected = {
         string: 'string',
         date: new Date(),
@@ -946,6 +1022,7 @@ describe('<Formik>', () => {
 
     it('should work correctly with instances in arrays', () => {
       class SomeClass {}
+
       const expected = {
         string: 'string',
         dateArr: [new Date(), new Date()],
@@ -958,6 +1035,7 @@ describe('<Formik>', () => {
 
     it('should work correctly with instances in objects', () => {
       class SomeClass {}
+
       const expected = {
         string: 'string',
         object: {
@@ -1133,7 +1211,7 @@ describe('<Formik>', () => {
   });
 
   it('should not warn when activeElement is not a button', () => {
-    const { getByTestId } = render(
+    render(
       <Formik onSubmit={noop} initialValues={{ opensource: 'yay' }}>
         {({ handleSubmit, handleChange, values }) => (
           <form onSubmit={handleSubmit} data-testid="form">
@@ -1149,10 +1227,10 @@ describe('<Formik>', () => {
         )}
       </Formik>
     );
-    const input = getByTestId('name-input');
+    const input = screen.getByTestId('name-input');
     input.focus(); // sets activeElement
 
-    fireEvent.submit(getByTestId('form'));
+    fireEvent.submit(screen.getByTestId('form'));
 
     expect(global.console.warn).not.toHaveBeenCalledWith(
       expect.stringMatching(
@@ -1172,7 +1250,11 @@ describe('<Formik>', () => {
     });
 
     expect(getProps().submitCount).toEqual(0);
-    await getProps().submitForm();
+
+    await act(async () => {
+      await getProps().submitForm();
+    });
+
     expect(onSubmit).toHaveBeenCalled();
     expect(getProps().submitCount).toEqual(1);
   });
@@ -1191,14 +1273,21 @@ describe('<Formik>', () => {
     expect(getProps().submitCount).toEqual(0);
     expect(getProps().isSubmitting).toBe(false);
     expect(getProps().isValidating).toBe(false);
-    // we call set isValidating synchronously
-    const validatePromise = getProps().submitForm();
+
+    let submitFormPromise: Promise<any>;
+    act(() => {
+      // we call set isValidating synchronously
+      submitFormPromise = getProps().submitForm();
+    });
+
     // so it should change
     expect(getProps().isSubmitting).toBe(true);
     expect(getProps().isValidating).toBe(true);
-    // do it again async
     try {
-      await validatePromise;
+      await act(async () => {
+        // resolve the promise to check final state.
+        await submitFormPromise;
+      });
     } catch (err) {}
     // now both should be false because validation failed
     expect(getProps().isSubmitting).toBe(false);
@@ -1220,13 +1309,22 @@ describe('<Formik>', () => {
     expect(getProps().submitCount).toEqual(0);
     expect(getProps().isSubmitting).toBe(false);
     expect(getProps().isValidating).toBe(false);
-    // we call set isValidating synchronously
-    const validatePromise = getProps().submitForm();
+
+    let submitFormPromise: Promise<any>;
+    act(() => {
+      // we call set isValidating synchronously
+      submitFormPromise = getProps().submitForm();
+    });
+
     // so it should change
     expect(getProps().isSubmitting).toBe(true);
     expect(getProps().isValidating).toBe(true);
-    // do it again async
-    await validatePromise;
+
+    await act(async () => {
+      // resolve the promise to check final state.
+      await submitFormPromise;
+    });
+
     // done validating and submitting
     expect(getProps().isSubmitting).toBe(true);
     expect(getProps().isValidating).toBe(false);
@@ -1247,13 +1345,22 @@ describe('<Formik>', () => {
     expect(getProps().submitCount).toEqual(0);
     expect(getProps().isSubmitting).toBe(false);
     expect(getProps().isValidating).toBe(false);
-    // we call set isValidating synchronously
-    const validatePromise = getProps().submitForm();
+    let submitFormPromise: Promise<any>;
+
+    act(() => {
+      // we call set isValidating synchronously
+      submitFormPromise = getProps().submitForm();
+    });
+
     // so it should change
     expect(getProps().isSubmitting).toBe(true);
     expect(getProps().isValidating).toBe(true);
-    // do it again async
-    await validatePromise;
+
+    await act(async () => {
+      // resolve the promise to check final state.
+      await submitFormPromise;
+    });
+
     // done validating and submitting
     expect(getProps().isSubmitting).toBe(false);
     expect(getProps().isValidating).toBe(false);
@@ -1269,12 +1376,20 @@ describe('<Formik>', () => {
     });
 
     expect(getProps().isValidating).toBe(false);
-    // we call set isValidating synchronously
-    const validatePromise = getProps().validateForm();
+
+    let validatePromise: Promise<any>;
+    act(() => {
+      // we call set isValidating synchronously
+      validatePromise = getProps().validateForm();
+    });
+
     expect(getProps().isValidating).toBe(true);
-    await validatePromise;
+
+    await act(async () => {
+      await validatePromise;
+    });
+
     expect(validate).toHaveBeenCalled();
-    // so it should change
     expect(getProps().isValidating).toBe(false);
   });
 
@@ -1296,9 +1411,12 @@ describe('<Formik>', () => {
       validationSchema,
     });
 
-    await getProps().validateForm();
-    expect(getProps().errors).toEqual({
-      users: [{ firstName: 'required', lastName: 'required' }],
+    await act(async () => {
+      await getProps().validateForm();
+
+      expect(getProps().errors).toEqual({
+        users: [{ firstName: 'required', lastName: 'required' }],
+      });
     });
   });
 
@@ -1312,9 +1430,17 @@ describe('<Formik>', () => {
       validationSchema,
     });
 
-    expect(() => {
-      getProps().validateForm();
-    }).toThrow('broken validations');
+    let caughtError: string = '';
+
+    await act(async () => {
+      try {
+        await getProps().validateForm();
+      } catch ({ message }) {
+        caughtError = message;
+      }
+    });
+
+    expect(caughtError).toEqual('broken validations');
   });
 
   it('exposes formikbag as imperative methods', () => {

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent, wait } from 'react-testing-library';
+import { render, fireEvent, wait } from '@testing-library/react';
 import * as Yup from 'yup';
 
 import {

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, wait } from 'react-testing-library';
+import { render, wait } from '@testing-library/react';
 import * as Yup from 'yup';
 
 import { withFormik, FormikProps } from '../src';

--- a/packages/formik/test/withFormik.test.tsx
+++ b/packages/formik/test/withFormik.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, wait } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import * as Yup from 'yup';
 
 import { withFormik, FormikProps } from '../src';
@@ -125,8 +125,10 @@ describe('withFormik()', () => {
     const myProps = { my: 'prop' };
     const { getProps } = renderWithFormik({ validate }, myProps);
 
-    getProps().submitForm();
-    await wait(() =>
+    act(() => {
+      getProps().submitForm();
+    });
+    await waitFor(() =>
       expect(validate).toHaveBeenCalledWith({ name: 'jared' }, myProps)
     );
   });
@@ -137,8 +139,10 @@ describe('withFormik()', () => {
       validationSchema: { validate },
     });
 
-    getProps().submitForm();
-    await wait(() => expect(validate).toHaveBeenCalled());
+    act(() => {
+      getProps().submitForm();
+    });
+    await waitFor(() => expect(validate).toHaveBeenCalled());
   });
 
   it('calls validationSchema function with props', async () => {
@@ -151,8 +155,10 @@ describe('withFormik()', () => {
       myProps
     );
 
-    getProps().submitForm();
-    await wait(() => expect(validationSchema).toHaveBeenCalledWith(myProps));
+    act(() => {
+      getProps().submitForm();
+    });
+    await waitFor(() => expect(validationSchema).toHaveBeenCalledWith(myProps));
   });
 
   it('calls handleSubmit with values, actions and custom props', async () => {
@@ -165,9 +171,11 @@ describe('withFormik()', () => {
       myProps
     );
 
-    getProps().submitForm();
+    act(() => {
+      getProps().submitForm();
+    });
 
-    await wait(() =>
+    await waitFor(() =>
       expect(handleSubmit).toHaveBeenCalledWith(
         { name: 'jared' },
         {

--- a/packages/formik/types/index.d.ts
+++ b/packages/formik/types/index.d.ts
@@ -1,4 +1,3 @@
-declare module 'react-testing-library';
 declare module 'tiny-warning' {
   export default function warning(condition: any, message: string): void;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,6 +1090,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.7.4":
   version "7.7.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.7.6.tgz#5b1044ea11b659d288f77190e19c62da959ed9a3"
@@ -1098,14 +1106,14 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.3", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4":
   version "7.7.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.6.tgz#d18c511121aff1b4f2cd1d452f1bac9601dd830f"
   integrity sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.10.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -1682,15 +1690,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
@@ -1700,6 +1699,17 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@jest/types@^26.3.0":
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
+  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@lerna/add@3.19.0":
   version "3.19.0"
@@ -2622,11 +2632,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
-  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
-
 "@sindresorhus/is@^1.0.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-1.2.0.tgz#63ce3638cb85231f3704164c90a18ef816da3fb7"
@@ -2645,6 +2650,32 @@
   integrity sha512-F7vS53bV9NXT+mmYFeSBr2nXaOI1h6qxdlLDVP+4CPG/c60MMStT7aaqYD2TSNWob1DA3GH9ikFY0UW31bUsWA==
   dependencies:
     defer-to-connect "^1.1.1"
+
+"@testing-library/dom@^7.24.2":
+  version "7.24.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.3.tgz#dae3071463cf28dc7755b43d9cf2202e34cbb85d"
+  integrity sha512-6eW9fUhEbR423FZvoHRwbWm9RUUByLWGayYFNVvqTnQLYvsNpBS4uEuKH9aqr3trhxFwGVneJUonehL3B1sHJw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.10.3"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.1"
+    pretty-format "^26.4.2"
+
+"@testing-library/react@^11.0.4":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.4.tgz#c84082bfe1593d8fcd475d46baee024452f31dee"
+  integrity sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@testing-library/dom" "^7.24.2"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
+  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.1.7":
   version "7.1.9"
@@ -2766,6 +2797,13 @@
   integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^25.2.1":
@@ -2918,13 +2956,6 @@
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
   integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
-
-"@types/yargs@^13.0.0":
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
-  integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.7"
@@ -3333,6 +3364,14 @@ aria-query@^3.0.0:
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^1.0.1:
   version "1.1.0"
@@ -5177,15 +5216,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-testing-library@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-4.1.1.tgz#615af61bee06db51bd8ecea60c113eba7cb49dda"
-  integrity sha512-PUsG7aY5BJxzulDrOtkksqudRRypcVQF6d4RGAyj9xNwallOFqrNLOyg2QW2mCpFaNVPELX8hBX/wbHQtOto/A==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^24.7.0"
-    wait-for-expect "^1.1.1"
+dom-accessibility-api@^0.5.1:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.3.tgz#0ea493c924d4070dfbf531c4aaca3d7a2c601aab"
+  integrity sha512-yfqzAi1GFxK6EoJIZKgxqJyK6j/OjEFEUi2qkNThD/kUhoCFSG1izq31B5xuxzbJBGw9/67uPtkPMYAzWL7L7Q==
 
 dom-walk@^0.1.0:
   version "0.1.2"
@@ -10723,22 +10757,22 @@ pretty-format@24.0.0-alpha.6:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.7.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
   dependencies:
     "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
+  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
+  dependencies:
+    "@jest/types" "^26.3.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
@@ -10981,7 +11015,7 @@ react-is@^16.12.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -11048,14 +11082,6 @@ react-proxy@^1.1.7:
   dependencies:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
-
-react-testing-library@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-7.0.1.tgz#0cf113bb53a78599f018378f6854e91a52dbf205"
-  integrity sha512-doQkM3/xPcIm22x9jgTkGxU8xqXg4iWvM1WwbbQ7CI5/EMk3DhloYBwMyk+Ywtta3dIAIh9sC7llXoKovf3L+w==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    dom-testing-library "^4.1.0"
 
 react-transform-hmr@^1.0.4:
   version "1.0.4"
@@ -13414,11 +13440,6 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.3.0.tgz#65241ce355425f907f5d127bdb5e72c412ff830c"
-  integrity sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This PR updates react testing library to the latest version (11.0.4) in the Formik dependencies, and refactors existing tests to continue to pass. Resolves a Question I opened the other day: https://github.com/formium/formik/issues/2798

* renamed `wait` to `waitFor`
* wrapped things in `act` as necessary
* replaced some `getByTestId` with direct usage from `screen.getByTestId` (mentioned as best practice by Kent C Dodds [in this article](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen))
* replaced `reactDOM.render`s with RTL's `render`.

Note: I unexpectedly had to add an `await` to the last test for FieldArray (`should run arrayHelpers successfully`). I am not familiar enough with the library, but it seems like there may be a race condition?

```
arrayHelpers.push('michael');
el = arrayHelpers.pop();
// el === undefined ❌ 
```

```
await arrayHelpers.push('michael');
el = arrayHelpers.pop();
// el === 'michael' ✅ 
```
