### PR TITLE
Fix typos on Checkboxes Example Page

### DIFF
--- a/docs/src/pages/docs/examples/checkboxes.md
+++ b/docs/src/pages/docs/examples/checkboxes.md
@@ -1,9 +1,9 @@
 ---
 title: Checkboxes Example
-description: This example demonstrates how to use Formik with a checkbox group. Given that the field's all share the same `name`, Formik will automagically bind them to an single array.
+description: This example demonstrates how to use Formik with a checkbox group. Given that the fields all share the same `name`, Formik will automagically bind them to a single array.
 ---
 
-This example demonstrates how to use Formik with a checkbox group. Given that the field's all share the same `name`, Formik will automagically bind them to an single array.
+This example demonstrates how to use Formik with a checkbox group. Given that the fields all share the same `name`, Formik will automagically bind them to a single array.
 
 <div className="embed-responsive aspect-ratio-square">
   <iframe


### PR DESCRIPTION
Changes "field's" to "fields" and "an" to "a".

Thanks for the project!