### PR TITLE
Hook to scroll to the first error of a Formik form

### DIFF
--- a/docs/src/pages/docs/api/utils.md
+++ b/docs/src/pages/docs/api/utils.md
@@ -12,6 +12,8 @@ custom_edit_url: https://github.com/jaredpalmer/formik/edit/master/docs/api/util
 
 #### `getIn(obj: any, key: string | string[], def?: any, p?: number): any`
 
+#### `isFirstIn(obj: any, key: string): boolean`
+
 #### `setIn(obj: any, path: string, value: any): any`
 
 #### `setNestedObjectValues<T>(object: any, value: any, visited?: any, response?: any): T`

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -582,9 +582,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   const setValues = useEventCallback(
     (values: React.SetStateAction<Values>, shouldValidate?: boolean) => {
-      const resolvedValues = isFunction(values)
-        ? values(state.values)
-        : values;
+      const resolvedValues = isFunction(values) ? values(state.values) : values;
 
       dispatch({ type: 'SET_VALUES', payload: resolvedValues });
       const willValidate =

--- a/packages/formik/src/index.tsx
+++ b/packages/formik/src/index.tsx
@@ -9,4 +9,4 @@ export * from './connect';
 export * from './ErrorMessage';
 export * from './FormikContext';
 export * from './FastField';
-export * from './useOnFirstError'
+export * from './useOnFirstError';

--- a/packages/formik/src/index.tsx
+++ b/packages/formik/src/index.tsx
@@ -9,3 +9,4 @@ export * from './connect';
 export * from './ErrorMessage';
 export * from './FormikContext';
 export * from './FastField';
+export * from './useOnFirstError'

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -87,7 +87,10 @@ export interface FormikHelpers<Values> {
     shouldValidate?: boolean
   ) => void;
   /** Manually set values object  */
-  setValues: (values: React.SetStateAction<Values>, shouldValidate?: boolean) => void;
+  setValues: (
+    values: React.SetStateAction<Values>,
+    shouldValidate?: boolean
+  ) => void;
   /** Set value of form field directly */
   setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
   /** Set error message of a form field directly */

--- a/packages/formik/src/useOnFirstError.ts
+++ b/packages/formik/src/useOnFirstError.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { useFormikContext } from 'formik'
+
+import { isFirstIn } from './utils'
+
+export const useOnFirstError = (
+  name: string,
+  scrollRef: React.RefObject<HTMLElement>,
+  focusRef?: React.RefObject<HTMLInputElement>
+) => {
+  const { errors, isSubmitting, isValidating } = useFormikContext()
+
+  useEffect(() => {
+    if (isSubmitting && !isValidating && isFirstIn(errors, name)) {
+      focusRef?.current?.focus()
+      scrollRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' })
+    }
+  }, [errors, name, isSubmitting, isValidating, scrollRef, focusRef])
+}

--- a/packages/formik/src/useOnFirstError.ts
+++ b/packages/formik/src/useOnFirstError.ts
@@ -4,7 +4,7 @@ import { useFormikContext } from 'formik';
 import { isFirstIn } from './utils';
 
 /**
- * This hook checks if the give name appears first in the errors object and if it is then scrolls to that element and
+ * This hook checks if the given name appears first in the errors object and if it is then scrolls to that element and
  * optionally brings it in focus if it is an input element.
  * @param name
  * @param scrollRef

--- a/packages/formik/src/useOnFirstError.ts
+++ b/packages/formik/src/useOnFirstError.ts
@@ -1,19 +1,31 @@
-import { useEffect } from 'react'
-import { useFormikContext } from 'formik'
+import { useEffect } from 'react';
+import { useFormikContext } from 'formik';
 
-import { isFirstIn } from './utils'
+import { isFirstIn } from './utils';
+
+/**
+ * This hook checks if the give name appears first in the errors object and if it is then scrolls to that element and
+ * optionally brings it in focus if it is an input element.
+ * @param name
+ * @param scrollRef
+ * @param focusRef
+ */
 
 export const useOnFirstError = (
   name: string,
   scrollRef: React.RefObject<HTMLElement>,
   focusRef?: React.RefObject<HTMLInputElement>
 ) => {
-  const { errors, isSubmitting, isValidating } = useFormikContext()
+  const { errors, isSubmitting, isValidating } = useFormikContext();
 
   useEffect(() => {
     if (isSubmitting && !isValidating && isFirstIn(errors, name)) {
-      focusRef?.current?.focus()
-      scrollRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' })
+      focusRef?.current?.focus();
+      scrollRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'center',
+      });
     }
-  }, [errors, name, isSubmitting, isValidating, scrollRef, focusRef])
-}
+  }, [errors, name, isSubmitting, isValidating, scrollRef, focusRef]);
+};

--- a/packages/formik/src/useOnFirstError.ts
+++ b/packages/formik/src/useOnFirstError.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useFormikContext } from 'formik';
+import { useFormikContext } from './FormikContext';
 
 import { isFirstIn } from './utils';
 

--- a/packages/formik/src/utils.ts
+++ b/packages/formik/src/utils.ts
@@ -80,6 +80,27 @@ export function getIn(
 }
 
 /**
+* Returns true if the given name (key) is the first one to appear in the given obj (object)
+ * @param obj
+ * @param name
+ * @return boolean
+ */
+export function isFirstIn(obj: any, key: string) {
+  const path = toPath(key)
+  let p = 0
+
+  while (obj && p < path.length) {
+    if (path[p] === Object.keys(obj)[0]) {
+      obj = obj[path[p++]]
+    } else {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
  * Deeply set a value from in object via it's path. If the value at `path`
  * has changed, return a shallow copy of obj with `value` set at `path`.
  * If `value` has not changed, return the original `obj`.

--- a/packages/formik/src/utils.ts
+++ b/packages/formik/src/utils.ts
@@ -80,24 +80,24 @@ export function getIn(
 }
 
 /**
-* Returns true if the given name (key) is the first one to appear in the given obj (object)
+ * Returns true if the given name (key) is the first one to appear in the given obj (object)
  * @param obj
  * @param name
  * @return boolean
  */
 export function isFirstIn(obj: any, key: string) {
-  const path = toPath(key)
-  let p = 0
+  const path = toPath(key);
+  let p = 0;
 
   while (obj && p < path.length) {
     if (path[p] === Object.keys(obj)[0]) {
-      obj = obj[path[p++]]
+      obj = obj[path[p++]];
     } else {
-      return false
+      return false;
     }
   }
 
-  return true
+  return true;
 }
 
 /**

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { act, cleanup, render, waitFor, fireEvent } from '@testing-library/react';
+import {
+  act,
+  cleanup,
+  render,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
 import * as Yup from 'yup';
 import {
   Formik,
@@ -364,7 +370,7 @@ describe('Field / FastField', () => {
 
         act(() => {
           getFormProps().validateField('name');
-        })
+        });
 
         rerender();
         await waitFor(() => {
@@ -386,7 +392,7 @@ describe('Field / FastField', () => {
 
         act(() => {
           getFormProps().validateField('name');
-        })
+        });
 
         expect(validate).toHaveBeenCalled();
         await waitFor(() => expect(getFormProps().errors.name).toBe('Error!'));
@@ -410,7 +416,7 @@ describe('Field / FastField', () => {
 
         act(() => {
           getFormProps().validateField('name');
-        })
+        });
 
         await waitFor(() =>
           expect(getFormProps().errors).toEqual({

--- a/packages/formik/test/utils.test.tsx
+++ b/packages/formik/test/utils.test.tsx
@@ -1,6 +1,7 @@
 import {
   isEmptyArray,
   setIn,
+  isFirstIn,
   getIn,
   setNestedObjectValues,
   isPromise,
@@ -168,6 +169,45 @@ describe('utils', () => {
     });
   });
 
+  describe('isFirstIn', () => {
+    it('should work on flat error objects ', () => {
+      const errors = { firstName: 'Error', lastName: 'Error' }
+
+      expect(isFirstIn(errors, 'firstName')).toEqual(true)
+      expect(isFirstIn(errors, 'lastName')).toEqual(false)
+    })
+
+    it('should work on nested error objects', () => {
+      const errors = { address: { postalCode: 'Error', houseNumber: 'Error' } }
+
+      expect(isFirstIn(errors, 'address')).toEqual(true)
+      expect(isFirstIn(errors, 'address.postalCode')).toEqual(true)
+      expect(isFirstIn(errors, 'address.houseNumber')).toEqual(false)
+    })
+
+    it('should work on arrays', () => {
+      const errors = { foo: [{ bar: 'Error', baz: 'Error' }] }
+
+      expect(isFirstIn(errors, 'foo[0].bar')).toEqual(true)
+      expect(isFirstIn(errors, 'foo.0.bar')).toEqual(true)
+      expect(isFirstIn(errors, 'foo[0].baz')).toEqual(false)
+      expect(isFirstIn(errors, 'foo.0.baz')).toEqual(false)
+    })
+
+    it('should work on arrays where the first indexes are valid', () => {
+      let errors = {
+        foo: {
+          5: { bar: 'Error', foo: 'Error' },
+          6: { bar: 'Error', foo: 'Error' },
+        },
+      }
+
+      expect(isFirstIn(errors, 'foo[5].bar')).toEqual(true)
+      expect(isFirstIn(errors, 'foo[5].foo')).toEqual(false)
+      expect(isFirstIn(errors, 'foo[6].bar')).toEqual(false)
+    })
+  })
+
   describe('setIn', () => {
     it('sets flat value', () => {
       const obj = { x: 'y' };
@@ -290,7 +330,7 @@ describe('utils', () => {
 
     it('should keep class inheritance for the top level object', () => {
       class TestClass {
-        constructor(public key: string, public setObj?: any) {}
+        constructor(public key: string, public setObj?: any) { }
       }
       const obj = new TestClass('value');
       const newObj = setIn(obj, 'setObj.nested', 'setInValue');

--- a/packages/formik/test/utils.test.tsx
+++ b/packages/formik/test/utils.test.tsx
@@ -171,28 +171,28 @@ describe('utils', () => {
 
   describe('isFirstIn', () => {
     it('should work on flat error objects ', () => {
-      const errors = { firstName: 'Error', lastName: 'Error' }
+      const errors = { firstName: 'Error', lastName: 'Error' };
 
-      expect(isFirstIn(errors, 'firstName')).toEqual(true)
-      expect(isFirstIn(errors, 'lastName')).toEqual(false)
-    })
+      expect(isFirstIn(errors, 'firstName')).toEqual(true);
+      expect(isFirstIn(errors, 'lastName')).toEqual(false);
+    });
 
     it('should work on nested error objects', () => {
-      const errors = { address: { postalCode: 'Error', houseNumber: 'Error' } }
+      const errors = { address: { postalCode: 'Error', houseNumber: 'Error' } };
 
-      expect(isFirstIn(errors, 'address')).toEqual(true)
-      expect(isFirstIn(errors, 'address.postalCode')).toEqual(true)
-      expect(isFirstIn(errors, 'address.houseNumber')).toEqual(false)
-    })
+      expect(isFirstIn(errors, 'address')).toEqual(true);
+      expect(isFirstIn(errors, 'address.postalCode')).toEqual(true);
+      expect(isFirstIn(errors, 'address.houseNumber')).toEqual(false);
+    });
 
     it('should work on arrays', () => {
-      const errors = { foo: [{ bar: 'Error', baz: 'Error' }] }
+      const errors = { foo: [{ bar: 'Error', baz: 'Error' }] };
 
-      expect(isFirstIn(errors, 'foo[0].bar')).toEqual(true)
-      expect(isFirstIn(errors, 'foo.0.bar')).toEqual(true)
-      expect(isFirstIn(errors, 'foo[0].baz')).toEqual(false)
-      expect(isFirstIn(errors, 'foo.0.baz')).toEqual(false)
-    })
+      expect(isFirstIn(errors, 'foo[0].bar')).toEqual(true);
+      expect(isFirstIn(errors, 'foo.0.bar')).toEqual(true);
+      expect(isFirstIn(errors, 'foo[0].baz')).toEqual(false);
+      expect(isFirstIn(errors, 'foo.0.baz')).toEqual(false);
+    });
 
     it('should work on arrays where the first indexes are valid', () => {
       let errors = {
@@ -200,13 +200,13 @@ describe('utils', () => {
           5: { bar: 'Error', foo: 'Error' },
           6: { bar: 'Error', foo: 'Error' },
         },
-      }
+      };
 
-      expect(isFirstIn(errors, 'foo[5].bar')).toEqual(true)
-      expect(isFirstIn(errors, 'foo[5].foo')).toEqual(false)
-      expect(isFirstIn(errors, 'foo[6].bar')).toEqual(false)
-    })
-  })
+      expect(isFirstIn(errors, 'foo[5].bar')).toEqual(true);
+      expect(isFirstIn(errors, 'foo[5].foo')).toEqual(false);
+      expect(isFirstIn(errors, 'foo[6].bar')).toEqual(false);
+    });
+  });
 
   describe('setIn', () => {
     it('sets flat value', () => {
@@ -330,7 +330,7 @@ describe('utils', () => {
 
     it('should keep class inheritance for the top level object', () => {
       class TestClass {
-        constructor(public key: string, public setObj?: any) { }
+        constructor(public key: string, public setObj?: any) {}
       }
       const obj = new TestClass('value');
       const newObj = setIn(obj, 'setObj.nested', 'setInValue');


### PR DESCRIPTION
This PR adds the functionality to scroll to the first error of a formik form. This is done using a react hook upon formik validation. When there are validation errors as defined in the Yup validation schema then this hook checks in the `errors` object from `FormikContext` to see if the given element is the first one to appear and if it is then does the necessary action of scrolling to that element and optionally bringing it in focus if it is an `input` element. This hook can be placed selectively on any `input | div | span` but not limited to these aforementioned elements.

The order of the keys in the formik errors object is determined by the order of those fields in the Yup validationSchema, so one can order these in the same order as the fields appear on the form.

The hook can be used in the following way:
```
import React, { useRef } from 'react'
import { useField, useFormikContext } from 'formik'

import { useOnFirstError } from './useOnFirstError'

type Props = { 
  name: string
}

const InputField = ({ name }: Props) => {
  const [field, meta, helpers] = useField(name)
  const inputRef = useRef<HTMLInputElement>(null)

  useOnFirstError(name, inputRef)

  return <input {...field} ref={inputRef}  />
}

<Formik ...>
  <InputField name="firstName" />
  <InputField name="lastName" />
</Formik>
```
This PR uses a function `isFirstIn` from the other PR which can be found [here](https://github.com/formium/formik/pull/2812)

This is a very common use case which can be supported in Formik forms.
