### PR TITLE
chore: change react peer dependency to v16.8

### DIFF
--- a/packages/formik-native/package.json
+++ b/packages/formik-native/package.json
@@ -28,7 +28,7 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react": ">=16.3.0"
+    "react": ">=16.8.0"
   },
   "dependencies": {
     "formik": "2.2.0"


### PR DESCRIPTION
formik-native is using hooks, but hooks were introduced only in react version 16.8