### PR TITLE
Publish next branch to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - next
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This allows us to run changesets on `next` branch