### PR TITLE
Fix 'Formik render methods and props' redirect url

### DIFF
--- a/docs/src/pages/docs/api/withFormik.md
+++ b/docs/src/pages/docs/api/withFormik.md
@@ -217,4 +217,4 @@ component's `errors`. Its keys should match those of `values`.
 
 ## Injected props and methods
 
-These are identical to the props of [`<Formik render={props => ...} />`](./formik.md#formik-render-methods-and-props)
+These are identical to the props of [`<Formik render={props => ...} />`](./formik#formik-render-methods-and-props)


### PR DESCRIPTION
The previous rendered url was : 
[https://formik.org/docs/api/formik.md#formik-render-methods-and-props](https://formik.org/docs/api/formik.md#formik-render-methods-and-props)
which led to a 404 page:
![image](https://user-images.githubusercontent.com/13598885/98209480-176c5400-1f67-11eb-98e2-0e7891f294ce.png)
