### PR TITLE
Fix low priority validation for browser password autofill.

### DIFF
--- a/app/pages/sign-in.js
+++ b/app/pages/sign-in.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ErrorMessage, Field, Form, Formik } from 'formik';
+import * as Yup from 'yup';
+
+const SignIn = () => (
+  <div>
+    <h1>Sign In</h1>
+
+    <Formik
+      validateOnMount={true}
+      initialValues={{ username: '', password: '' }}
+      validationSchema={Yup.object().shape({
+        username: Yup.string().required('Required'),
+        password: Yup.string().required('Required'),
+      })}
+      onSubmit={async values => {
+        await new Promise(r => setTimeout(r, 500));
+        alert(JSON.stringify(values, null, 2));
+      }}
+    >
+      {formik => (
+        <Form>
+          <div>
+            <Field name="username" placeholder="Username" />
+            <ErrorMessage name="username" component="p" />
+          </div>
+
+          <div>
+            <Field name="password" placeholder="Password" type="password" />
+            <ErrorMessage name="password" component="p" />
+          </div>
+
+          <button type="submit" disabled={!formik.isValid}>
+            Submit
+          </button>
+        </Form>
+      )}
+    </Formik>
+  </div>
+);
+
+export default SignIn;

--- a/cypress/integration/basic.spec.ts
+++ b/cypress/integration/basic.spec.ts
@@ -14,4 +14,30 @@ describe('basic validation', () => {
 
     cy.get('#renderCounter').contains('0');
   });
+
+  it('should validate autofill', () => {
+    // React overrides `input.value` setters, so we have to call
+    // native input setter
+    // See: https://stackoverflow.com/a/46012210/1709679
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value'
+    )?.set;
+
+    function setInputValue(input: HTMLElement, value: string) {
+      nativeInputValueSetter?.call(input, value);
+      const event = new Event('change', { bubbles: true });
+      input.dispatchEvent(event);
+    }
+
+    cy.visit('http://localhost:3000/sign-in');
+
+    cy.get('body').then($body => {
+      // We have set value through JS to simulate autofill behavior.
+      setInputValue($body.find('input[name="username"]')[0], '123');
+      setInputValue($body.find('input[name="password"]')[0], '123');
+    });
+
+    cy.get('button').should('not.be.disabled');
+  });
 });

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -86,8 +86,8 @@ function formikReducer<Values>(
         //
         // So we want to skip validation results if values are not the same
         // anymore.
-        state.values !== msg.payload.values ||
-        isEqual(state.errors, msg.payload.errors)
+        isEqual(state.errors, msg.payload.errors) ||
+        !isEqual(state.values, msg.payload.values)
       ) {
         return state;
       }


### PR DESCRIPTION
Follow-up fix for the https://github.com/formium/formik/pull/2854#issuecomment-722529976

Some edge cases impossible to test without mocking `scheduler` internals, but since all the `scheduler` methods considered unstable I think the best way is to test inside the browser.