### PR TITLE
fix[FastField]: initial values in case of radio and checkbox

### DIFF
--- a/.changeset/tough-dragons-dream.md
+++ b/.changeset/tough-dragons-dream.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+fix FastField initial value when input type is radio or checkbox

--- a/packages/formik/src/FastField.tsx
+++ b/packages/formik/src/FastField.tsx
@@ -137,15 +137,7 @@ class FastFieldInner<Values = {}, Props = {}> extends React.Component<
       validationSchema: _validationSchema,
       ...restOfFormik
     } = formik;
-    const field = {
-      value:
-        props.type === 'radio' || props.type === 'checkbox'
-          ? props.value // React uses checked={} for these inputs
-          : getIn(formik.values, name),
-      name,
-      onChange: formik.handleChange,
-      onBlur: formik.handleBlur,
-    };
+    const field = formik.getFieldProps({ name, ...props });
     const meta = {
       value: getIn(formik.values, name),
       error: getIn(formik.errors, name),


### PR DESCRIPTION
Resolves - https://github.com/formium/formik/issues/2297

As FastField doesn't set initial values when the input type is radio or checkbox