### PR TITLE
ci: change stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 3600
+daysUntilClose: 60
 # Issues with these labels will never be considered stale
 exemptLabels:
   - enhancement
@@ -10,9 +10,14 @@ exemptLabels:
   - bug
   - in progress
   - 2.0
+  - 3.0
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: false
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true


### PR DESCRIPTION
### Changes
- Decrease `daysUntilStale` days to just 30 days
- Decrease `daysUntilClose` to 60 days
- Adding `3.0` in exempted labels
- Also exempting project and milestone issues