### PR TITLE
Remove unnecessary deep equality when dispatching errors

### DIFF
--- a/.changeset/thick-penguins-smile.md
+++ b/.changeset/thick-penguins-smile.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+Remove unnecessary deep equality when dispatching errors

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -325,9 +325,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
       return runAllValidations(values).then(combinedErrors => {
         if (!!isMounted.current) {
           dispatch({ type: 'SET_ISVALIDATING', payload: false });
-          if (!isEqual(state.errors, combinedErrors)) {
-            dispatch({ type: 'SET_ERRORS', payload: combinedErrors });
-          }
+          dispatch({ type: 'SET_ERRORS', payload: combinedErrors });
         }
         return combinedErrors;
       });


### PR DESCRIPTION
This is already checked for in the reducer. It can also cause race conditions if a new validation result arrives before the dispatcher has had a chance to process the action.