### PR TITLE
ci: bump cypress

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         with:
           start: npm run start:app
           wait-on: 'http://localhost:3000'


### PR DESCRIPTION
Fixes the Deprecation Warning for `set-env` https://github.com/cypress-io/github-action/issues/206