### PR TITLE
[docs] Fix material-ui broken link

### DIFF
--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -51,16 +51,6 @@
           ]
         },
         {
-          "title": "With React UI Frameworks",
-          "open": false,
-          "routes": [
-            {
-              "title": "Material UI",
-              "path": "/docs/with-react-ui-frameworks/with-material-ui.md"
-            }
-          ]
-        },
-        {
           "title": "Examples",
           "open": true,
           "routes": [


### PR DESCRIPTION
The link "With React UI Frameworks" / "Material UI" is currently broken. I noticed that the page it points to is in the examples. Since it's a duplicate, I chose to remove it. But let me know if you'd prefer to keep it and fix the URL.

For the record, it's currently pointing to: https://formik.org/docs/with-react-ui-frameworks/with-material-ui while the page is there: https://formik.org/docs/examples/with-material-ui