### PR TITLE
 Skip setValues side effects if returned value is unchanged

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -551,7 +551,14 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   const setValues = useEventCallback(
     (values: React.SetStateAction<Values>, shouldValidate?: boolean) => {
-      const resolvedValues = isFunction(values) ? values(state.values) : values;
+      let resolvedValues = values;
+      if (isFunction(values)) {
+        resolvedValues = values(state.values);
+        // If your update function returns the exact same value as the current state,
+        // the subsequent rerender will be skipped completely.
+        // @see https://reactjs.org/docs/hooks-reference.html#functional-updates
+        if (resolvedValues === state.values) return Promise.resolve();
+      }
 
       dispatch({ type: 'SET_VALUES', payload: resolvedValues });
       const willValidate =

--- a/packages/formik/test/Formik.test.tsx
+++ b/packages/formik/test/Formik.test.tsx
@@ -653,6 +653,20 @@ describe('<Formik>', () => {
         expect(getProps().values.age).toEqual(80);
       });
 
+      it('setValues should do nothing if values returned from function are unchanged', async () => {
+        const validate = jest.fn(() => Promise.resolve({}));
+        const { getProps } = renderFormik<Values>({ validate });
+
+        act(() => {
+          getProps().setValues((values: Values) => values);
+        });
+        // rerender();
+        await waitFor(() => {
+          expect(getProps().values).toEqual(InitialValues);
+          expect(validate).not.toHaveBeenCalled();
+        });
+      });
+
       it('setValues should run validations when validateOnChange is true (default)', async () => {
         const newValue: Values = { name: 'ian' };
         const validate = jest.fn(_values => ({}));


### PR DESCRIPTION
I am thrilled that support for functional updates was added to `setValues`, but I noticed that there is a subtle but key difference between the way React `setState` handles functional updates and the way `setValues` handles them. If you look at the [React docs for functional updates with `setState`](https://reactjs.org/docs/hooks-reference.html#functional-updates), it notes that:

> If your update function returns the exact same value as the current state, the subsequent rerender will be skipped completely.

This allows you to skip an update and subsequent validation if the new values are unchanged, which is important for some side effects (for example, data returns from the server and I only want to update the values if it is different than the current values).