### PR TITLE
chore(docs): Change functional component type in Typescript example

### DIFF
--- a/docs/src/pages/docs/guides/typescript.md
+++ b/docs/src/pages/docs/guides/typescript.md
@@ -26,7 +26,7 @@ interface MyFormValues {
   firstName: string;
 }
 
-export const MyApp: React.ReactElement = () => {
+export const MyApp = (): React.ReactElement => {
   const initialValues: MyFormValues = { firstName: '' };
   return (
     <div>

--- a/docs/src/pages/docs/guides/typescript.md
+++ b/docs/src/pages/docs/guides/typescript.md
@@ -26,7 +26,7 @@ interface MyFormValues {
   firstName: string;
 }
 
-export const MyApp: React.FC<{}> = () => {
+export const MyApp: React.ReactElement = () => {
   const initialValues: MyFormValues = { firstName: '' };
   return (
     <div>


### PR DESCRIPTION
Hi all 👋 ,

I believe `React.FC` is better avoided as it doesn't offer too many benefits (see https://github.com/facebook/create-react-app/pull/8177). If you are required to explicitly declare a type because your project settings urge you to do so, then  `ReactElement` is the safe shot imo.

Note that this is an opinionated PR, please let me know what you think. 

Happy holidays 🙂 🎄 