### PR TITLE
Allow explicitly setting action to empty string

### DIFF
--- a/packages/formik/src/Form.tsx
+++ b/packages/formik/src/Form.tsx
@@ -17,7 +17,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
     // iOS needs an "action" attribute for nice input: https://stackoverflow.com/a/39485162/406725
     // We default the action to "#" in case the preventDefault fails (just updates the URL hash)
     const { action, ...rest } = props;
-    const _action = action || '#';
+    const _action = action ?? '#';
     const { handleReset, handleSubmit } = useFormikContext();
     return (
       <form


### PR DESCRIPTION
If someone actually wants to do a standard http post to the same page. 