### PR TITLE
Fix yarn dev error cannot find module webpack on website docs

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,12 +1,6 @@
-const webpack = require('webpack');
 const fs = require('fs');
 const path = require('path');
-const visit = require('unist-util-visit');
 const remarkPlugins = require('./src/lib/docs/remark-plugins');
-const {
-  NOTION_TOKEN,
-  BLOG_INDEX_ID,
-} = require('./src/lib/notion/server-constants');
 
 try {
   fs.unlinkSync(path.resolve('.blog_index_data'));


### PR DESCRIPTION
When i tried to run the development server of the docs, i got this error.

<img width="476" alt="Screenshot 2021-01-31 at 6 44 37 PM" src="https://user-images.githubusercontent.com/25560419/106381586-d0222200-63f4-11eb-93b5-5a63718a9e36.png">

Thus i checked the file and i found some unused dependencies in the file mentioned above including `webpack` which is not part of the module. So i had to remove it to make it work. I am not sure why it's there, especially since the website is built on NextJS which shouldn't require webpack. Is it correct ?
