### PR TITLE
chore: add @deprecated for isInitialValid

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -161,6 +161,7 @@ export interface FormikSharedConfig<Props = {}> {
   /** Tells Formik to validate upon mount */
   validateOnMount?: boolean;
   /** Tell Formik if initial form values are valid or not on first render */
+  /** @deprecated in 2.x, use initialErrors instead */
   isInitialValid?: boolean | ((props: Props) => boolean);
   /** Should Formik reset the form when new initialValues change */
   enableReinitialize?: boolean;


### PR DESCRIPTION
The option `isInitialValid` is deprecated in 2.x by the document.

https://formik.org/docs/api/formik#isinitialvalid-boolean

I want the code editor to show to be deprecation, like this.

<img width="457" alt="スクリーンショット 2021-02-01 21 32 28" src="https://user-images.githubusercontent.com/12580072/106459295-ff0fc500-64d4-11eb-8400-65d064aed5f6.png">

I want you to keep this option though, if possible...

https://github.com/formium/formik/issues/2061