### PR TITLE
Make favicon href path absolute

### DIFF
--- a/website/src/components/Seo.tsx
+++ b/website/src/components/Seo.tsx
@@ -25,8 +25,8 @@ export const Seo = withRouter(
       {description != undefined && (
         <meta name="description" key="description" content={description} />
       )}
-      <link rel="icon" type="image/x-icon" href="images/favicon.png" />
-      <link rel="apple-touch-icon" href="images/favicon.png" />
+      <link rel="icon" type="image/x-icon" href="/images/favicon.png" />
+      <link rel="apple-touch-icon" href="/images/favicon.png" />
 
       {/* OPEN GRAPH */}
       <meta property="og:type" key="og:type" content="website" />


### PR DESCRIPTION
The way it is now does not work for the docs section, which I noticed at URLs like https://formik.org/docs/overview .

Please let me know if you need something different for this PR. Good package!