### PR TITLE
Fix setError type

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -299,7 +299,7 @@ export interface FieldHelperProps<Value> {
   /** Set the field's touched value */
   setTouched: (value: boolean, shouldValidate?: boolean) => void;
   /** Set the field's error value */
-  setError: (value: Value) => void;
+  setError: (value: any) => void;
 }
 
 /** Field input value, name, and event handlers */


### PR DESCRIPTION
setError accepts an error not the Field's value type. The actual code implementing this interface is actually written `setError: (value: any) => setFieldError(name, value)`.