### PR TITLE
deps(packages/formik): Use lodash@4.17.21 & lodash-es@4.17.21

### DIFF
--- a/packages/formik/package.json
+++ b/packages/formik/package.json
@@ -30,7 +30,9 @@
   "umd:main": "dist/formik.umd.production.js",
   "module": "dist/formik.esm.js",
   "typings": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "peerDependencies": {
     "react": ">=16.8.0"
   },
@@ -45,8 +47,8 @@
   "dependencies": {
     "deepmerge": "^2.1.1",
     "hoist-non-react-statics": "^3.3.0",
-    "lodash": "^4.17.14",
-    "lodash-es": "^4.17.14",
+    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "react-fast-compare": "^2.0.1",
     "tiny-warning": "^1.0.2",
     "tslib": "^1.10.0"


### PR DESCRIPTION
`Snyk` vulnerability
- Update `lodash` to `4.17.21`
- Update `lodash-es` to `4.17.21`