### PR TITLE
Removing enclosed { } from validationSchema

### DIFF
--- a/examples/SchemaValidation.js
+++ b/examples/SchemaValidation.js
@@ -28,7 +28,7 @@ const SignUp = () => (
         firstName: '',
         lastName: '',
       }}
-      validationSchema={SignUpSchema}
+      validationSchema=SignUpSchema
       onSubmit={values => {
         setTimeout(() => {
           alert(JSON.stringify(values, null, 2));


### PR DESCRIPTION
it returns error "TypeError: schema[(intermediate value)(intermediate value)(intermediate value)] is not a function" if validationSchema is enclosed with { }

As seen on https://github.com/jquense/yup/issues/972