### PR TITLE
Errors not showing in MUI sandbox as onBlur is not called

### DIFF
--- a/examples/with-material-ui/index.js
+++ b/examples/with-material-ui/index.js
@@ -38,6 +38,7 @@ const WithMaterialUI = () => {
           label="Email"
           value={formik.values.email}
           onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
           error={formik.touched.email && Boolean(formik.errors.email)}
           helperText={formik.touched.email && formik.errors.email}
         />
@@ -48,6 +49,7 @@ const WithMaterialUI = () => {
           label="Password"
           type="password"
           value={formik.values.password}
+          onBlur={formik.handleBlur}
           onChange={formik.handleChange}
           error={formik.touched.password && Boolean(formik.errors.password)}
           helperText={formik.touched.password && formik.errors.password}


### PR DESCRIPTION
The formik MUI example sandbox is not showing errors as the as the touched property is set by the onBlur event which is not being called. 

## Before
<img width="2201" alt="Screenshot 2021-03-24 at 23 49 51" src="https://user-images.githubusercontent.com/44759513/112398537-5b84a900-8cfc-11eb-952d-b51a6753e595.png">

## After

<img width="2194" alt="Screenshot 2021-03-24 at 23 50 16" src="https://user-images.githubusercontent.com/44759513/112398563-66d7d480-8cfc-11eb-9c03-2d71fb4661be.png">
