### PR TITLE
added setFieldValue function overload for better editor support

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -92,7 +92,8 @@ export interface FormikHelpers<Values> {
     shouldValidate?: boolean
   ) => void;
   /** Set value of form field directly */
-  setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
+  setFieldValue(field: keyof Values, value: any, shouldValidate?: boolean): void;
+  setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
   /** Set error message of a form field directly */
   setFieldError: (field: string, message: string | undefined) => void;
   /** Set whether field has been touched directly */


### PR DESCRIPTION
most of the time, we probably want to `setFieldValue` one of the existing fields in initial values, so it's good to have some editor support for it. :)

![Screenshot_20210329_122730](https://user-images.githubusercontent.com/46019949/112805518-eb26b080-908a-11eb-8093-8eade4c50dde.png)

I expected something like this to work out but it doesn't:
```setFieldValue = (field: keyof Values | string, value: any, shouldValidate?: boolean) => void;‍‍‍‍‍‍```