### PR TITLE
Update documentation relative links to include extension

### DIFF
--- a/docs/api/formik.md
+++ b/docs/api/formik.md
@@ -93,11 +93,11 @@ to `<button onClick={handleReset}>...</button>`
 
 #### `handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void`
 
-Submit handler. This should be passed to `<form onSubmit={props.handleSubmit}>...</form>`. To learn more about the submission process, see [Form Submission](../guides/form-submission).
+Submit handler. This should be passed to `<form onSubmit={props.handleSubmit}>...</form>`. To learn more about the submission process, see [Form Submission](../guides/form-submission.md).
 
 #### `isSubmitting: boolean`
 
-Submitting state of the form. Returns `true` if submission is in progress and `false` otherwise. IMPORTANT: Formik will set this to `true` as soon as submission is _attempted_. To learn more about the submission process, see [Form Submission](../guides/form-submission).
+Submitting state of the form. Returns `true` if submission is in progress and `false` otherwise. IMPORTANT: Formik will set this to `true` as soon as submission is _attempted_. To learn more about the submission process, see [Form Submission](../guides/form-submission.md).
 
 #### `isValid: boolean`
 
@@ -107,7 +107,7 @@ Returns `true` if there are no `errors` (i.e. the `errors` object is empty) and 
 
 #### `isValidating: boolean`
 
-Returns `true` if Formik is running validation during submission, or by calling [`validateForm`] directly `false` otherwise. To learn more about what happens with `isValidating` during the submission process, see [Form Submission](../guides/form-submission).
+Returns `true` if Formik is running validation during submission, or by calling [`validateForm`] directly `false` otherwise. To learn more about what happens with `isValidating` during the submission process, see [Form Submission](../guides/form-submission.md).
 
 #### `resetForm: (nextState?: Partial<FormikState<Values>>) => void`
 
@@ -204,7 +204,7 @@ use it to pass API responses back into your component in `handleSubmit`.
 
 #### `setSubmitting: (isSubmitting: boolean) => void`
 
-Set `isSubmitting` imperatively. You would call it with `setSubmitting(false)` in your `onSubmit` handler to finish the cycle. To learn more about the submission process, see [Form Submission](../guides/form-submission).
+Set `isSubmitting` imperatively. You would call it with `setSubmitting(false)` in your `onSubmit` handler to finish the cycle. To learn more about the submission process, see [Form Submission](../guides/form-submission.md).
 
 #### `setTouched: (fields: { [field: string]: boolean }, shouldValidate?: boolean) => void`
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -326,7 +326,7 @@ export const DisplayingErrorMessagesExample = () => (
 );
 ```
 
-> The [ErrorMessage](../api/errormessage) component can also be used to display error messages.
+> The [ErrorMessage](../api/errormessage.md) component can also be used to display error messages.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
The relative links within the docs for [`api/formik`](https://formik.org/docs/api/formik) and `[guides/validation](https://formik.org/docs/guides/validation)` did not include a `.md` file extension and the code in `rehype-docs.js` was [expecting one](https://github.com/formium/formik/blob/master/website/src/lib/docs/rehype-docs.js#L12-L18). Due to the lack of extension on these relative doc files, the call to `basePath.lastIndexOf('.');` is getting the "dot" in the relative path `../`. Simply adding `.md` to these relative links correctly fixes the routing in the notion documentation