### PR TITLE
Require `ExtraProps` to be explicit

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -987,10 +987,11 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   return ctx;
 }
 
+type NoInfer<A> = [A, never][A extends any ? 0 : 1];
 export function Formik<
   Values extends FormikValues = FormikValues,
   ExtraProps = {}
->(props: FormikConfig<Values> & ExtraProps) {
+>(props: FormikConfig<Values> & NoInfer<ExtraProps>) {
   const formikbag = useFormik<Values>(props);
   const { component, children, render, innerRef } = props;
 


### PR DESCRIPTION
As explained in #3170, due to type inference TS is unable to report typos when passing unknown properties to `<Formik />`

This proposal uses a conditional type `NoInfer<T>` to bypass type inference for the `ExtraProps` type parameter, while still enabling users to pass it explicitly.

Please note this is a opinionated proposal, therefor further discussion may be needed.
closes #3170