### PR TITLE
Add note about using React.Fragment within FieldArrray

### DIFF
--- a/docs/examples/field-arrays.md
+++ b/docs/examples/field-arrays.md
@@ -13,3 +13,6 @@ This example demonstrates how to work with array fields in Formik.
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
   ></iframe>
 </div>
+
+
+> **_NOTE:_** You must not use a ```React.Fragment``` Element as child within the ```FieldArray```.


### PR DESCRIPTION
I generally try to avoid using `<div>`s where they are not necessary to avoid building huge pyramids in the dom.  
In many instances, replacing `<div>` tags with `<React.Fragment>` works without issue.  
Sadly, here it causes the render to fail with a somewhat cryptic error message that does not show where the issue lies and is difficult to debug.

While creating an issue for this would be possible, I am unsure if it is "wanted" behavior and therefore I thought it would be best to just propose a change to the docs, warning about this.