### PR TITLE
Stop testing against node 12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          version: 12.x
+          version: 16.x
 
       - name: Install deps and build (with cache)
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['12.x']
+        node: ['14.x', '16.x']
 
     name: Test on node ${{ matrix.node }}
 


### PR DESCRIPTION
Changes test matrices to drop Node.js 12, which is in maintenance