### PR TITLE
Docs: @types/yup no longer required

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -68,7 +68,6 @@ To add Yup to your project, install it from NPM.
 
 ```sh
 npm install yup --save
-# typescript users should add the @types/yup
 ```
 
 ```jsx


### PR DESCRIPTION
Seems that recently yup moved to have built-in typscript support https://github.com/jquense/yup/blob/HEAD/docs/typescript.md
https://www.npmjs.com/package/yup shows as typescript package:
![image](https://user-images.githubusercontent.com/12865914/118683319-94736280-b801-11eb-8b62-664902be384a.png)
