### PR TITLE
fix:  value  is same as message in  setFieldError

### DIFF
--- a/.changeset/stupid-boxes-tease.md
+++ b/.changeset/stupid-boxes-tease.md
@@ -1,0 +1,5 @@
+---
+'formik': patch
+---
+
+Fixes type of setError value as it is same as setFieldError message

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -299,7 +299,7 @@ export interface FieldHelperProps<Value> {
   /** Set the field's touched value */
   setTouched: (value: boolean, shouldValidate?: boolean) => void;
   /** Set the field's error value */
-  setError: (value: Value) => void;
+  setError: (value: string | undefined) => void;
 }
 
 /** Field input value, name, and event handlers */


### PR DESCRIPTION
setError is setFieldError bound to specific field. Therefore the setError value should have same type as setFieldError message