### PR TITLE
add useFormik return type

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -14,6 +14,7 @@ import {
   FieldInputProps,
   FormikHelpers,
   FormikHandlers,
+  FormikApi,
 } from './types';
 import {
   isFunction,
@@ -137,7 +138,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   enableReinitialize = false,
   onSubmit,
   ...rest
-}: FormikConfig<Values>) {
+}: FormikConfig<Values>): FormikApi<Values> {
   const props = {
     validateOnChange,
     validateOnBlur,
@@ -947,7 +948,7 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     [isInitialValid, dirty, state.errors, props]
   );
 
-  const ctx = {
+  const ctx: FormikApi<Values> = {
     ...state,
     initialValues: initialValues.current,
     initialErrors: initialErrors.current,

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -150,16 +150,19 @@ export interface FormikHandlers {
   getFieldHelpers: <Value = any>(name: string) => FieldHelperProps<Value>;
 }
 
-/**
- * Base formik configuration/props shared between the HoC and Component.
- */
-export interface FormikSharedConfig<Props = {}> {
+export interface FormikValidationConfig {
   /** Tells Formik to validate the form on each input's onChange event */
   validateOnChange?: boolean;
   /** Tells Formik to validate the form on each input's onBlur event */
   validateOnBlur?: boolean;
   /** Tells Formik to validate upon mount */
   validateOnMount?: boolean;
+}
+
+/**
+ * Base formik configuration/props shared between the HoC and Component.
+ */
+export interface FormikSharedConfig<Props = {}> extends FormikValidationConfig {
   /** Tell Formik if initial form values are valid or not on first render */
   isInitialValid?: boolean | ((props: Props) => boolean);
   /** Should Formik reset the form when new initialValues change */
@@ -247,6 +250,14 @@ export interface FormikRegistration {
   registerField: (name: string, fns: { validate?: FieldValidator }) => void;
   unregisterField: (name: string) => void;
 }
+
+export type FormikApi<Values extends FormikValues = FormikValues> =
+  & FormikHelpers<Values>
+  & FormikHandlers
+  & FormikRegistration
+  & FormikComputedProps<Values>
+  & FormikState<Values>
+  & FormikValidationConfig;
 
 /**
  * State, handlers, and helpers made available to Formik's primitive components through context.

--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -251,13 +251,14 @@ export interface FormikRegistration {
   unregisterField: (name: string) => void;
 }
 
-export type FormikApi<Values extends FormikValues = FormikValues> =
-  & FormikHelpers<Values>
-  & FormikHandlers
-  & FormikRegistration
-  & FormikComputedProps<Values>
-  & FormikState<Values>
-  & FormikValidationConfig;
+export type FormikApi<
+  Values extends FormikValues = FormikValues
+> = FormikHelpers<Values> &
+  FormikHandlers &
+  FormikRegistration &
+  FormikComputedProps<Values> &
+  FormikState<Values> &
+  FormikValidationConfig;
 
 /**
  * State, handlers, and helpers made available to Formik's primitive components through context.


### PR DESCRIPTION
Based on https://github.com/formium/formik/issues/2924

Create return type for useFormik.
Based on @johnrom 's  v3 commit for some naming: https://github.com/formium/formik/pull/3121/files#diff-2421f0a25f33b0ee81ca1de9dee2a1743711e08f273a5733ed03493de527de21R135-R137

But if you have a better name for the return type, please tell me and I'll refactor it.

------------------

Will explain step by step how I did it so you can have a quick look on my steps and maybe detect a bug without checking the code:

- Used the return type definition exported in dist.
- Removed 1 by 1 the fields when I found a good type which encapsulated all the props with the same firm.
- Had to divide the current type: FormikSharedConfig. Extracted from there FormikValidationConfig.
- Profit

