### PR TITLE
Ensure FieldArray helpers leave touched/errors in valid state when in…

### DIFF
--- a/packages/formik/src/FieldArray.tsx
+++ b/packages/formik/src/FieldArray.tsx
@@ -172,12 +172,12 @@ class FieldArrayInner<Values = {}> extends React.Component<
         fn(getIn(prevState.values, name))
       );
 
-      let fieldError = alterErrors
-        ? updateErrors(getIn(prevState.errors, name))
-        : undefined;
-      let fieldTouched = alterTouched
-        ? updateTouched(getIn(prevState.touched, name))
-        : undefined;
+      const prevErrors = getIn(prevState.errors, name);
+      let fieldError =
+        alterErrors && !!prevErrors ? updateErrors(prevErrors) : undefined;
+      const prevTouched = getIn(prevState.touched, name);
+      let fieldTouched =
+        alterTouched && !!prevTouched ? updateTouched(prevTouched) : undefined;
 
       if (isEmptyArray(fieldError)) {
         fieldError = undefined;

--- a/packages/formik/test/FieldArray.test.tsx
+++ b/packages/formik/test/FieldArray.test.tsx
@@ -384,6 +384,63 @@ describe('<FieldArray />', () => {
     });
   });
 
+  describe('props.move()', () => {
+    let formikBag: any;
+    let arrayHelpers: any;
+
+    beforeEach(() => {
+      render(
+        <TestForm>
+          {(props: any) => {
+            formikBag = props;
+            return (
+              <FieldArray
+                name="friends"
+                render={arrayProps => {
+                  arrayHelpers = arrayProps;
+                  return null;
+                }}
+              />
+            );
+          }}
+        </TestForm>
+      );
+    });
+    it('should move an item and touched/errors', () => {
+      act(() => {
+        formikBag.setErrors({ friends: [undefined, 'Field error', undefined] });
+        formikBag.setTouched({ friends: [undefined, true, undefined] });
+      });
+
+      act(() => {
+        arrayHelpers.move(0, 2);
+      });
+
+      expect(formikBag.values.friends).toEqual(['andrea', 'brent', 'jared']);
+      expect(formikBag.errors.friends).toEqual([
+        'Field error',
+        undefined,
+        undefined,
+      ]);
+      expect(formikBag.touched.friends).toEqual([true, undefined, undefined]);
+    });
+
+    it('should handle empty touched/errors', () => {
+      act(() => {
+        formikBag.setErrors({ friends: undefined });
+        formikBag.setTouched({ friends: undefined });
+      });
+
+      act(() => {
+        arrayHelpers.move(0, 2);
+      });
+
+      expect(formikBag.values.friends).toEqual(['andrea', 'brent', 'jared']);
+      expect(formikBag.errors.friends).toEqual(undefined);
+      expect(formikBag.touched.friends).toEqual(undefined);
+    });
+  });
+
   describe('given array-like object representing errors', () => {
     it('should run arrayHelpers successfully', async () => {
       let formikBag: any;


### PR DESCRIPTION
…itially empty

Fixes https://github.com/formium/formik/issues/1616
Related to https://github.com/formium/formik/pull/1782

And added unit tests for `move`, including covering this behaviour