### PR TITLE
Remove __dev__ condition overkill

### DIFF
--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -142,7 +142,6 @@ export function Field({
     ...formik
   } = useFormikContext();
 
-  if (__DEV__) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       invariant(
@@ -166,7 +165,6 @@ export function Field({
       );
       // eslint-disable-next-line
     }, []);
-  }
 
   // Register field and field-level validation with parent <Formik>
   const { registerField, unregisterField } = formik;


### PR DESCRIPTION
`tiny-warning` only warns in production mode.