### PR TITLE
Limit stale to only specific labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,4 +16,4 @@ jobs:
           stale-pr-label: "stale"
           stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 60 days"
           stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 60 days"
-          exempt-issue-labels: "enhancement,pinned,RFC,in progress,3.0"
+          any-of-labels: "Resolution: Duplicate,Resolution: Invalid,Resolution: Support Redirect,Resolution: Unsolved,Resolution: User Land,Resolution: Wontfix,Resolution: Workaround,Status: Author Feedback,Status: Needs More Information"


### PR DESCRIPTION
So maintainers can opt into stale instead of issues becoming stale before they are looked at.

- `Resolution: *` any issue marked as resolved via some method like a workaround or support redirect that is not closed by a PR.
- `Status: Needs more information`
- `Status: Author Feedback`
