### PR TITLE
Fix error in FastField docs - Field render

### DIFF
--- a/docs/api/fastfield.md
+++ b/docs/api/fastfield.md
@@ -105,7 +105,7 @@ const Basic = () => (
            and all changes by all <Field>s and <FastField>s */}
           <label htmlFor="lastName">LastName</label>
           <Field name="lastName" placeholder="Baby">
-            {() => (
+            {({ field, form }) => (
               <div>
                 <input {...field} />
                 {/**  Works because this is inside


### PR DESCRIPTION
The example cost in the FastField docs has a component that does not unpack the render props. This PR simply adds in the props so that the example can be copy/pasted without error.