### PR TITLE
add allValues for field level validation

### DIFF
--- a/packages/formik/src/types.tsx
+++ b/packages/formik/src/types.tsx
@@ -318,6 +318,7 @@ export interface FieldInputProps<Value> {
   onBlur: FormikHandlers['handleBlur'];
 }
 
-export type FieldValidator = (
-  value: any
+export type FieldValidator<Values = any> = (
+  value: any,
+  allValues: Values
 ) => string | void | Promise<string | void>;

--- a/packages/formik/test/Field.test.tsx
+++ b/packages/formik/test/Field.test.tsx
@@ -425,6 +425,27 @@ describe('Field / FastField', () => {
         );
       }
     );
+
+    cases(
+      'runs validation with field value and all form values',
+      async (renderField) => {
+        const validate = jest.fn();
+        const value = 'ideffix';
+        const {getByTestId, rerender} = renderField({
+          validate,
+          component: 'input',
+        })
+        rerender();
+        fireEvent.change(getByTestId('name-input'), {
+          target: { name: 'name', value },
+        });
+        rerender()
+        await waitFor(() => {
+          expect(validate.mock.calls[0]).toEqual([value, {email: initialValues.email, name: value}])
+        })
+      }
+    )
+
   });
 
   describe('warnings', () => {


### PR DESCRIPTION
### What?
Add `allValues` as second parameter to validate function on `Field` level
### Why?
Sometimes our validation is dependent on other field so its usefull to have all form values
### Example
`<Field name={'startDate'} component={Datepicker} />`
`<Field name={'endDate'} component={Datepicker} validate={(value, allValues) => isBefore(value, allValues.startDate) ? 'End date cannot be before start date!' : undefined} />`