### PR TITLE
Update `editUrl` on siteConfig.tsx

### DIFF
--- a/website/src/siteConfig.tsx
+++ b/website/src/siteConfig.tsx
@@ -1,7 +1,7 @@
 // List of projects/orgs using your project for the users page.
 
 export const siteConfig = {
-  editUrl: 'https://github.com/formik/formik/edit/master/docs/src/pages',
+  editUrl: 'https://github.com/formik/formik/edit/master',
   copyright: `Copyright © ${new Date().getFullYear()} Jared Palmer. All Rights Reserved.`,
   repoUrl: 'https://github.com/formik/formik',
   discordUrl: 'https://discord.com/invite/pJSg287',


### PR DESCRIPTION
The `Edit this page on GitHub` text at in the doc footers lead to non-existent GitHub pages because of a new routing change. 